### PR TITLE
Add image upload support

### DIFF
--- a/client/src/pages/AttendancePage.jsx
+++ b/client/src/pages/AttendancePage.jsx
@@ -71,27 +71,28 @@ function AttendancePage() {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    // Build payload as JSON since the backend currently expects JSON data
+    // Build form data so the backend can handle file uploads
     const validEmployeeAttendances = employeeAttendances.filter(
       (att) => att.employeeId || att.checkIn || att.checkOut || att.otHours || att.remarks
     );
 
-    const payload = {
-      siteName,
-      attendanceDate,
-      siteSupervisorId: siteSupervisor,
-      supervisorCheckIn,
-      supervisorCheckOut,
-      supervisorOT,
-      supervisorRemarks,
-      employeeAttendances: JSON.stringify(validEmployeeAttendances),
-      // imageAttachment is ignored for now as backend does not handle uploads
-    };
+    const formData = new FormData();
+    formData.append('siteName', siteName);
+    formData.append('attendanceDate', attendanceDate);
+    formData.append('siteSupervisorId', siteSupervisor);
+    formData.append('supervisorCheckIn', supervisorCheckIn);
+    formData.append('supervisorCheckOut', supervisorCheckOut);
+    formData.append('supervisorOT', supervisorOT);
+    formData.append('supervisorRemarks', supervisorRemarks);
+    formData.append('employeeAttendances', JSON.stringify(validEmployeeAttendances));
+    if (imageAttachment) {
+      formData.append('imageAttachment', imageAttachment);
+    }
 
     try {
-      const response = await axios.post('/api/attendance', payload, {
+      const response = await axios.post('/api/attendance', formData, {
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'multipart/form-data',
         },
       });
       console.log('Attendance submitted successfully:', response.data);

--- a/client/src/pages/AttendanceReviewPage.jsx
+++ b/client/src/pages/AttendanceReviewPage.jsx
@@ -111,15 +111,18 @@ function AttendanceReviewPage() {
   const handleEditSubmit = async (e) => {
     e.preventDefault();
     try {
-      await axios.put(`/api/attendance/${editingForm}`, {
-        siteName: editData.siteName,
-        attendanceDate: editData.attendanceDate,
-        siteSupervisorId: editData.siteSupervisorId,
-        supervisorCheckIn: editData.supervisorCheckIn,
-        supervisorCheckOut: editData.supervisorCheckOut,
-        supervisorOT: editData.supervisorOT,
-        supervisorRemarks: editData.supervisorRemarks,
-        employeeAttendances: JSON.stringify(editData.employees)
+      const formData = new FormData();
+      formData.append('siteName', editData.siteName);
+      formData.append('attendanceDate', editData.attendanceDate);
+      formData.append('siteSupervisorId', editData.siteSupervisorId);
+      formData.append('supervisorCheckIn', editData.supervisorCheckIn);
+      formData.append('supervisorCheckOut', editData.supervisorCheckOut);
+      formData.append('supervisorOT', editData.supervisorOT);
+      formData.append('supervisorRemarks', editData.supervisorRemarks);
+      formData.append('employeeAttendances', JSON.stringify(editData.employees));
+
+      await axios.put(`/api/attendance/${editingForm}`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
       });
       setEditingForm(null);
       setEditData(null);
@@ -148,6 +151,15 @@ function AttendanceReviewPage() {
                 </p>
                 <p className="text-sm text-gray-600">เข้า: {form.supervisor_check_in || '-'} ออก: {form.supervisor_check_out || '-'}</p>
                 <p className="text-sm text-gray-600">OT: {form.supervisor_ot || '-'} หมายเหตุ: {form.supervisor_remarks || '-'}</p>
+                {form.image_attachment && (
+                  <div className="mt-2">
+                    <img
+                      src={`/uploads/${form.image_attachment}`}
+                      alt="แนบรูปไซต์"
+                      className="max-h-48 rounded"
+                    />
+                  </div>
+                )}
                 {form.employees.length > 0 && (
                   <table className="mt-2 w-full text-sm text-left">
                     <thead>

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
     proxy: {
       // String shorthand for simple cases:
       '/api': 'http://localhost:3000',
+      '/uploads': 'http://localhost:3000',
 
       // Using the object syntax for more control:
       // '/api': {

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.0",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/server/src/controllers/attendanceController.js
+++ b/server/src/controllers/attendanceController.js
@@ -13,6 +13,10 @@ exports.submitAttendanceForm = async (req, res) => {
     employeeAttendances
   } = req.body;
 
+  const imageFile = req.file ? req.file.filename : null;
+
+  const imageFile = req.file ? req.file.filename : null;
+
   const employees = []; 
   if (employeeAttendances) {
     try { employees.push(...JSON.parse(employeeAttendances)); } catch (e) {}
@@ -36,7 +40,7 @@ exports.submitAttendanceForm = async (req, res) => {
         supervisorCheckOut || null,
         supervisorOT || null,
         supervisorRemarks || null,
-        null
+        imageFile
       ]
     );
     const attendanceId = formRes.rows[0].id;
@@ -122,8 +126,9 @@ exports.updateForm = async (req, res) => {
          supervisor_check_out=$5,
          supervisor_ot=$6,
          supervisor_remarks=$7,
+         image_attachment=COALESCE($8, image_attachment),
          updated_at=CURRENT_TIMESTAMP
-       WHERE id=$8`,
+       WHERE id=$9`,
       [
         siteName,
         attendanceDate,
@@ -132,6 +137,7 @@ exports.updateForm = async (req, res) => {
         supervisorCheckOut || null,
         supervisorOT || null,
         supervisorRemarks || null,
+        imageFile,
         id
       ]
     );

--- a/server/src/routes/attendanceRoutes.js
+++ b/server/src/routes/attendanceRoutes.js
@@ -2,10 +2,13 @@ const express = require('express');
 const router = express.Router();
 const attendanceController = require('../controllers/attendanceController');
 const authMiddleware = require('../middleware/authMiddleware');
+const multer = require('multer');
+const path = require('path');
+const upload = multer({ dest: path.join(__dirname, '../../uploads') });
 
-router.post('/', attendanceController.submitAttendanceForm);
+router.post('/', upload.single('imageAttachment'), attendanceController.submitAttendanceForm);
 router.get('/pending', authMiddleware, attendanceController.getPendingForms);
-router.put('/:id', authMiddleware, attendanceController.updateForm);
+router.put('/:id', authMiddleware, upload.single('imageAttachment'), attendanceController.updateForm);
 router.delete('/:id', authMiddleware, attendanceController.deleteForm);
 router.put('/:id/verify', authMiddleware, attendanceController.verifyForm);
 router.get('/history', authMiddleware, attendanceController.getVerifiedForms);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -12,6 +12,7 @@ const PORT = process.env.PORT; //|| 3000;
 // Middleware
 app.use(cors()); // Enable CORS for all routes
 app.use(express.json()); // To parse JSON request bodies
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
 // Basic Route
 app.get('/api', (req, res) => {


### PR DESCRIPTION
## Summary
- support multipart form submission for attendance
- store uploaded images on the server
- display uploaded images on Attendance Review page
- allow editing attendance forms with multipart data
- proxy uploaded files to the backend server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in server *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_684a8f78b9c883238fc031f3b6ea58eb