### PR TITLE
Add Sunday tracking to attendance forms

### DIFF
--- a/client/src/pages/AttendanceReviewPage.jsx
+++ b/client/src/pages/AttendanceReviewPage.jsx
@@ -155,6 +155,9 @@ function AttendanceReviewPage() {
                 </p>
                 <p className="text-sm text-gray-600">เข้า: {form.supervisor_check_in || '-'} ออก: {form.supervisor_check_out || '-'}</p>
                 <p className="text-sm text-gray-600">OT: {form.supervisor_ot || '-'} หมายเหตุ: {form.supervisor_remarks || '-'}</p>
+                {form.is_sunday && (
+                  <p className="text-sm text-red-600 font-bold">วันอาทิตย์</p>
+                )}
                 {form.image_attachment && (
                   <div className="mt-2">
                     <img

--- a/client/src/pages/WorkHistoryPage.jsx
+++ b/client/src/pages/WorkHistoryPage.jsx
@@ -66,6 +66,9 @@ function WorkHistoryPage() {
                     <p className="text-sm text-gray-600">ออก: {form.supervisor_check_out || '-'} น.</p>
                     <p className="text-sm text-gray-600">OT: {form.supervisor_ot || '-'}</p>
                     <p className="text-sm text-gray-600">หมายเหตุ: {form.supervisor_remarks || '-'}</p>
+                    {form.is_sunday && (
+                      <p className="text-sm text-red-600 font-bold">วันอาทิตย์</p>
+                    )}
                     <p className="text-sm text-black-600 font-bold">เบี้ยขยัน: {form.is_bonus ? 'ใช่' : 'ไม่ใช่'}</p>
                     {form.image_attachment && (
                       <div className="mt-2">

--- a/server/db_schema.sql
+++ b/server/db_schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS AttendanceForms (
     supervisor_ot NUMERIC(5,2),
     supervisor_remarks TEXT,
     image_attachment TEXT,
+    is_sunday BOOLEAN DEFAULT FALSE,
     is_bonus BOOLEAN DEFAULT FALSE,
     is_verified BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/server/src/controllers/attendanceController.js
+++ b/server/src/controllers/attendanceController.js
@@ -2,6 +2,11 @@ const pool = require('../config/db');
 const fs = require('fs');
 const path = require('path');
 
+const isSunday = (dateStr) => {
+  const d = new Date(dateStr);
+  return !isNaN(d) && d.getDay() === 0;
+};
+
 // User submits attendance form
 exports.submitAttendanceForm = async (req, res) => {
   const {
@@ -29,8 +34,8 @@ exports.submitAttendanceForm = async (req, res) => {
         site_name, attendance_date, site_supervisor_id,
         supervisor_check_in, supervisor_check_out,
         supervisor_ot, supervisor_remarks, image_attachment,
-        is_bonus, is_verified, created_at, updated_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,false,false,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)
+        is_sunday, is_bonus, is_verified, created_at, updated_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,false,false,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)
       RETURNING id`,
       [
         siteName,
@@ -40,7 +45,8 @@ exports.submitAttendanceForm = async (req, res) => {
         supervisorCheckOut || null,
         supervisorOT || null,
         supervisorRemarks || null,
-        imageFile
+        imageFile,
+        isSunday(attendanceDate)
       ]
     );
     const attendanceId = formRes.rows[0].id;
@@ -127,8 +133,9 @@ exports.updateForm = async (req, res) => {
          supervisor_ot=$6,
          supervisor_remarks=$7,
          image_attachment=COALESCE($8, image_attachment),
+         is_sunday=$9,
          updated_at=CURRENT_TIMESTAMP
-       WHERE id=$9`,
+       WHERE id=$10`,
       [
         siteName,
         attendanceDate,
@@ -138,6 +145,7 @@ exports.updateForm = async (req, res) => {
         supervisorOT || null,
         supervisorRemarks || null,
         imageFile,
+        isSunday(attendanceDate),
         id
       ]
     );


### PR DESCRIPTION
## Summary
- add `is_sunday` column to `AttendanceForms`
- compute Sunday flag in attendance controller
- display forms using `is_sunday` property
- remove unused dateUtils helper

## Testing
- `npm run lint` in `client` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in `server` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_684bacd185b083238893496853c030c9