### PR TITLE
Add superuser admin creation page and API

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 import { getAuthToken, getAdminUser } from './utils/auth';
 import ProtectedRoute from './components/ProtectedRoute';
+import SuperuserRoute from './components/SuperuserRoute';
 import AdminNavbar from './components/AdminNavbar';
 import AttendancePage from './pages/AttendancePage';
 import AdminLoginPage from './pages/AdminLoginPage';
@@ -11,6 +12,7 @@ import EmployeeListPage from './pages/EmployeeListPage';
 import AttendanceReviewPage from './pages/AttendanceReviewPage';
 import WorkHistoryPage from './pages/WorkHistoryPage';
 import DeductionManagementPage from './pages/DeductionManagementPage';
+import AdminCreatePage from './pages/AdminCreatePage';
 
 // --- Main App Component ---
 function AppContent() {
@@ -90,6 +92,9 @@ function AppContent() {
           <Route path="/admin/attendance-review" element={<AttendanceReviewPage />} />
           <Route path="/admin/deductions" element={<DeductionManagementPage />} />
           <Route path="/admin/history" element={<WorkHistoryPage />} />
+          <Route element={<SuperuserRoute />}>
+            <Route path="/admin/create-admin" element={<AdminCreatePage />} />
+          </Route>
           <Route path="/admin" element={<Navigate to="/admin/employees" replace />} />
         </Route>
 

--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -13,6 +13,9 @@ const AdminNavbar = ({ adminUser, onLogout }) => {
           <Link to="/admin/employees" className="hover:text-gray-300">รายชื่อพนักงาน</Link>
           <Link to="/admin/attendance-review" className="hover:text-gray-300">ตรวจสอบการลงชื่อ</Link>
           <Link to="/admin/deductions" className="hover:text-gray-300">จัดการหักเงิน</Link>
+          {adminUser && adminUser.is_superuser && (
+            <Link to="/admin/create-admin" className="hover:text-gray-300">สร้างผู้ดูแล</Link>
+          )}
           <Link to="/admin/history" className="hover:text-gray-300">ประวัติการทำงาน</Link>
           <Link to="/" className="hover:text-gray-300">หน้าลงเวลา</Link>
           <button

--- a/client/src/components/SuperuserRoute.jsx
+++ b/client/src/components/SuperuserRoute.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { getAuthToken, getAdminUser } from '../utils/auth';
+
+const SuperuserRoute = () => {
+  const token = getAuthToken();
+  const user = getAdminUser();
+  if (!token) {
+    return <Navigate to="/admin/login" replace />;
+  }
+  if (!user || !user.is_superuser) {
+    return <Navigate to="/admin/employees" replace />;
+  }
+  return <Outlet />;
+};
+
+export default SuperuserRoute;

--- a/client/src/pages/AdminCreatePage.jsx
+++ b/client/src/pages/AdminCreatePage.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+function AdminCreatePage() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    username: '',
+    password: '',
+    is_superuser: false,
+  });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await axios.post('/api/admins', form);
+      alert('สร้างผู้ดูแลสำเร็จ');
+      setForm({ name: '', email: '', username: '', password: '', is_superuser: false });
+      navigate('/admin/employees');
+    } catch (err) {
+      console.error(err);
+      if (err.response && err.response.data && err.response.data.msg) {
+        setError(err.response.data.msg);
+      } else {
+        setError('ไม่สามารถสร้างผู้ดูแลได้');
+      }
+    }
+  };
+
+  return (
+    <div className="min-h-screen p-6 font-sans">
+      <h2 className="text-2xl font-semibold mb-4">สร้างผู้ดูแลระบบ</h2>
+      <form onSubmit={handleSubmit} className="max-w-md space-y-4">
+        <div>
+          <label className="block mb-1">ชื่อ</label>
+          <input
+            type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            className="border p-2 w-full"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">อีเมล</label>
+          <input
+            type="email"
+            name="email"
+            value={form.email}
+            onChange={handleChange}
+            className="border p-2 w-full"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">ชื่อผู้ใช้</label>
+          <input
+            type="text"
+            name="username"
+            value={form.username}
+            onChange={handleChange}
+            className="border p-2 w-full"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">รหัสผ่าน</label>
+          <input
+            type="password"
+            name="password"
+            value={form.password}
+            onChange={handleChange}
+            className="border p-2 w-full"
+            required
+          />
+        </div>
+        <div className="flex items-center">
+          <input
+            type="checkbox"
+            id="is_superuser"
+            name="is_superuser"
+            checked={form.is_superuser}
+            onChange={handleChange}
+            className="mr-2"
+          />
+          <label htmlFor="is_superuser">Superuser</label>
+        </div>
+        {error && <div className="text-red-600">{error}</div>}
+        <button type="submit" className="bg-sky-600 text-white px-4 py-2 rounded">
+          บันทึก
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default AdminCreatePage;

--- a/server/src/controllers/adminController.js
+++ b/server/src/controllers/adminController.js
@@ -1,0 +1,34 @@
+const pool = require('../config/db');
+const bcrypt = require('bcryptjs');
+
+exports.createAdmin = async (req, res) => {
+    const { name, email, username, password, is_superuser } = req.body;
+
+    if (!name || !email || !username || !password) {
+        return res.status(400).json({ msg: 'Please provide all required fields' });
+    }
+
+    try {
+        const existing = await pool.query(
+            'SELECT id FROM Admins WHERE username=$1 OR email=$2',
+            [username, email]
+        );
+        if (existing.rows.length > 0) {
+            return res.status(400).json({ msg: 'Username or email already exists' });
+        }
+
+        const salt = await bcrypt.genSalt(10);
+        const hash = await bcrypt.hash(password, salt);
+
+        const { rows } = await pool.query(
+            `INSERT INTO Admins (username, password_hash, email, name, is_superuser, created_at, updated_at)
+             VALUES ($1,$2,$3,$4,$5,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)
+             RETURNING id, username, email, name, is_superuser`,
+            [username, hash, email, name, is_superuser === true || is_superuser === 'true']
+        );
+        res.status(201).json(rows[0]);
+    } catch (err) {
+        console.error('Error in createAdmin:', err.message);
+        res.status(500).send('Server error while creating admin');
+    }
+};

--- a/server/src/controllers/authController.js
+++ b/server/src/controllers/authController.js
@@ -45,10 +45,12 @@ exports.loginAdmin = async (req, res) => {
                 if (err) throw err;
                 res.json({
                     token,
-                    admin: { // Send back some admin info (optional)
+                    admin: {
                         id: admin.id,
                         username: admin.username,
-                        email: admin.email
+                        email: admin.email,
+                        name: admin.name,
+                        is_superuser: admin.is_superuser
                     }
                 });
             }

--- a/server/src/middleware/superuserMiddleware.js
+++ b/server/src/middleware/superuserMiddleware.js
@@ -1,0 +1,22 @@
+const pool = require('../config/db');
+
+module.exports = async function(req, res, next) {
+    const adminId = req.admin && req.admin.id;
+    if (!adminId) {
+        return res.status(401).json({ msg: 'No admin ID in request' });
+    }
+
+    try {
+        const { rows } = await pool.query('SELECT is_superuser FROM Admins WHERE id=$1', [adminId]);
+        if (rows.length === 0) {
+            return res.status(404).json({ msg: 'Admin not found' });
+        }
+        if (!rows[0].is_superuser) {
+            return res.status(403).json({ msg: 'Access denied: superuser only' });
+        }
+        next();
+    } catch (err) {
+        console.error('Error in superuserMiddleware:', err.message);
+        res.status(500).send('Server error');
+    }
+};

--- a/server/src/routes/adminRoutes.js
+++ b/server/src/routes/adminRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const adminController = require('../controllers/adminController');
+const authMiddleware = require('../middleware/authMiddleware');
+const superuserMiddleware = require('../middleware/superuserMiddleware');
+
+router.post('/', authMiddleware, superuserMiddleware, adminController.createAdmin);
+
+module.exports = router;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -25,6 +25,7 @@ app.use('/api/auth', require('./routes/authRoutes')); // Mount authentication ro
 app.use('/api/employees', require('./routes/employeeRoutes'));
 app.use('/api/attendance', require('./routes/attendanceRoutes'));
 app.use('/api/deductions', require('./routes/deductionRoutes'));
+app.use('/api/admins', require('./routes/adminRoutes'));
 
 // Automatically remove last month's verified attendance records on the 10th of each month
 cron.schedule('0 0 10 * *', async () => {


### PR DESCRIPTION
## Summary
- add SuperuserRoute for pages that require superuser rights
- implement AdminCreatePage for creating admin accounts
- show create-admin link in admin navbar when logged in user is superuser
- secure API with superuser middleware and controller
- expose new `/api/admins` route
- include admin name and superuser flag in login response

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in server *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_684bd8ac64208323a1b60bb3df9b25cf