### PR TITLE
Add manage utility bills with history

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,7 @@ import WorkHistoryPage from './pages/WorkHistoryPage';
 import DeductionManagementPage from './pages/DeductionManagementPage';
 import AdminCreatePage from './pages/AdminCreatePage';
 import AdminListPage from './pages/AdminListPage';
+import BillHistoryPage from './pages/BillHistoryPage';
 
 
 // --- Main App Component ---
@@ -93,6 +94,7 @@ function AppContent() {
           <Route path="/admin/employees" element={<EmployeeListPage />} />
           <Route path="/admin/attendance-review" element={<AttendanceReviewPage />} />
           <Route path="/admin/deductions" element={<DeductionManagementPage />} />
+          <Route path="/admin/bill-history" element={<BillHistoryPage />} />
           <Route path="/admin/history" element={<WorkHistoryPage />} />
           <Route element={<SuperuserRoute />}>
             <Route path="/admin/create-admin" element={<AdminCreatePage />} />

--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -15,6 +15,7 @@ const AdminNavbar = ({ adminUser, onLogout }) => {
           <Link to="/admin/attendance-review" className="hover:text-gray-300">ตรวจสอบการลงชื่อ</Link>
           <Link to="/admin/history" className="hover:text-gray-300">ประวัติการทำงาน</Link>
           <Link to="/admin/deductions" className="hover:text-gray-300">จัดการหักเงิน</Link>
+          <Link to="/admin/bill-history" className="hover:text-gray-300">ประวัติค่าน้ำไฟ</Link>
           {adminUser && adminUser.is_superuser && (
             <>
               <Link to="/admin/create-admin" className="hover:text-gray-300">สร้างบัญชี Admin</Link>

--- a/client/src/pages/BillHistoryPage.jsx
+++ b/client/src/pages/BillHistoryPage.jsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function BillHistoryPage() {
+  const [waterAddresses, setWaterAddresses] = useState([]);
+  const [electricAddresses, setElectricAddresses] = useState([]);
+  const [selectedWater, setSelectedWater] = useState('');
+  const [selectedElectric, setSelectedElectric] = useState('');
+  const [waterBills, setWaterBills] = useState([]);
+  const [electricBills, setElectricBills] = useState([]);
+  const [error, setError] = useState('');
+
+  const fetchAddresses = async () => {
+    try {
+      const wRes = await axios.get('/api/deductions/water');
+      const eRes = await axios.get('/api/deductions/electric');
+      setWaterAddresses(wRes.data.map((d) => d.address_name));
+      setElectricAddresses(eRes.data.map((d) => d.address_name));
+    } catch (err) {
+      console.error(err);
+      setError('โหลดข้อมูลไม่สำเร็จ');
+    }
+  };
+
+  const fetchWaterHistory = async (addr) => {
+    if (!addr) return;
+    try {
+      const res = await axios.get(`/api/deductions/water/history/${encodeURIComponent(addr)}`);
+      setWaterBills(res.data);
+    } catch (err) {
+      console.error(err);
+      setError('โหลดประวัติค่าน้ำไม่สำเร็จ');
+    }
+  };
+
+  const fetchElectricHistory = async (addr) => {
+    if (!addr) return;
+    try {
+      const res = await axios.get(`/api/deductions/electric/history/${encodeURIComponent(addr)}`);
+      setElectricBills(res.data);
+    } catch (err) {
+      console.error(err);
+      setError('โหลดประวัติค่าไฟไม่สำเร็จ');
+    }
+  };
+
+  useEffect(() => {
+    fetchAddresses();
+  }, []);
+
+  useEffect(() => {
+    fetchWaterHistory(selectedWater);
+  }, [selectedWater]);
+
+  useEffect(() => {
+    fetchElectricHistory(selectedElectric);
+  }, [selectedElectric]);
+
+  return (
+    <div className="p-6 text-black">
+      <h2 className="text-2xl font-semibold mb-4">ประวัติค่าน้ำค่าไฟ</h2>
+      {error && <div className="text-red-600 mb-4">{error}</div>}
+
+      <div className="mb-8">
+        <h3 className="text-xl font-semibold mb-2">ค่าน้ำ</h3>
+        <select
+          value={selectedWater}
+          onChange={(e) => setSelectedWater(e.target.value)}
+          className="border p-2 mb-2"
+        >
+          <option value="">เลือกที่อยู่</option>
+          {waterAddresses.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+        {selectedWater && (
+          <table className="min-w-full bg-white shadow">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="px-4 py-2 text-left">เดือน</th>
+                <th className="px-4 py-2 text-left">ค่าน้ำ</th>
+                <th className="px-4 py-2 text-left">บิล</th>
+              </tr>
+            </thead>
+            <tbody>
+              {waterBills.map((b, idx) => (
+                <tr key={idx} className="border-t">
+                  <td className="px-4 py-2">{b.bill_month}</td>
+                  <td className="px-4 py-2">{b.water_charge}</td>
+                  <td className="px-4 py-2">
+                    {b.bill_image && (
+                      <a href={`/uploads/${b.bill_image}`} target="_blank" rel="noopener noreferrer" className="text-blue-600">ดูรูป</a>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div>
+        <h3 className="text-xl font-semibold mb-2">ค่าไฟ</h3>
+        <select
+          value={selectedElectric}
+          onChange={(e) => setSelectedElectric(e.target.value)}
+          className="border p-2 mb-2"
+        >
+          <option value="">เลือกที่อยู่</option>
+          {electricAddresses.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+        {selectedElectric && (
+          <table className="min-w-full bg-white shadow">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="px-4 py-2 text-left">เดือน</th>
+                <th className="px-4 py-2 text-left">หน่วยก่อนหน้า</th>
+                <th className="px-4 py-2 text-left">หน่วยปัจจุบัน</th>
+                <th className="px-4 py-2 text-left">บิลก่อน</th>
+                <th className="px-4 py-2 text-left">บิลปัจจุบัน</th>
+              </tr>
+            </thead>
+            <tbody>
+              {electricBills.map((b, idx) => (
+                <tr key={idx} className="border-t">
+                  <td className="px-4 py-2">{b.bill_month}</td>
+                  <td className="px-4 py-2">{b.last_unit}</td>
+                  <td className="px-4 py-2">{b.current_unit}</td>
+                  <td className="px-4 py-2">
+                    {b.bill_last_image && (
+                      <a href={`/uploads/${b.bill_last_image}`} target="_blank" rel="noopener noreferrer" className="text-blue-600">ดูรูป</a>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    {b.bill_current_image && (
+                      <a href={`/uploads/${b.bill_current_image}`} target="_blank" rel="noopener noreferrer" className="text-blue-600">ดูรูป</a>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BillHistoryPage;

--- a/server/db_schema.sql
+++ b/server/db_schema.sql
@@ -69,20 +69,34 @@ CREATE TABLE IF NOT EXISTS DeductionTypes (
 
 -- Water charge addresses
 CREATE TABLE IF NOT EXISTS WaterAddresses (
-    address_name TEXT PRIMARY KEY,
+    address_name TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS WaterBills (
+    id SERIAL PRIMARY KEY,
+    address_name TEXT REFERENCES WaterAddresses(address_name) ON DELETE CASCADE,
+    bill_month DATE NOT NULL,
     water_charge NUMERIC(10,2) NOT NULL DEFAULT 0,
     bill_image TEXT,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(address_name, bill_month)
 );
 
 -- Electric charge addresses
 CREATE TABLE IF NOT EXISTS ElectricAddresses (
-    address_name TEXT PRIMARY KEY,
+    address_name TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS ElectricBills (
+    id SERIAL PRIMARY KEY,
+    address_name TEXT REFERENCES ElectricAddresses(address_name) ON DELETE CASCADE,
+    bill_month DATE NOT NULL,
     last_unit NUMERIC(10,2) NOT NULL DEFAULT 0,
     current_unit NUMERIC(10,2) NOT NULL DEFAULT 0,
     bill_last_image TEXT,
     bill_current_image TEXT,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(address_name, bill_month)
 );
 
 -- Link employee water/electric addresses to respective tables

--- a/server/src/routes/deductionRoutes.js
+++ b/server/src/routes/deductionRoutes.js
@@ -13,14 +13,17 @@ router.put('/types/:id', authMiddleware, deductionController.updateDeductionType
 router.delete('/types/:id', authMiddleware, deductionController.deleteDeductionType);
 
 router.get('/water', authMiddleware, deductionController.getWaterCharges);
+router.get('/water/history/:address', authMiddleware, deductionController.getWaterHistory);
 router.put(
   '/water/:address',
   authMiddleware,
   upload.fields([{ name: 'bill', maxCount: 1 }]),
   deductionController.updateWaterCharge
 );
+router.delete('/water/:address', authMiddleware, deductionController.deleteWaterAddress);
 
 router.get('/electric', authMiddleware, deductionController.getElectricCharges);
+router.get('/electric/history/:address', authMiddleware, deductionController.getElectricHistory);
 router.put(
   '/electric/:address',
   authMiddleware,
@@ -30,5 +33,6 @@ router.put(
   ]),
   deductionController.updateElectricCharge
 );
+router.delete('/electric/:address', authMiddleware, deductionController.deleteElectricAddress);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- restructure water/electric tables to use history tables
- support editing month and saving bills with month info
- add bill history page to review past utility bills
- backend endpoints for bill history retrieval and month-based updates
- navigation link and route for bill history page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c09b1dba48323a5074032071582f1