### PR TITLE
Add bill management feedback

### DIFF
--- a/client/src/utils/date.js
+++ b/client/src/utils/date.js
@@ -19,3 +19,10 @@ export function formatThaiMonth(monthStr) {
   const mIndex = parseInt(month, 10) - 1;
   return `${thMonths[mIndex]} ${beYear}`;
 }
+
+export function getNextMonth(monthStr) {
+  if (!monthStr) return new Date().toISOString().slice(0, 7);
+  const date = new Date(`${monthStr}-01`);
+  date.setMonth(date.getMonth() + 1);
+  return date.toISOString().slice(0, 7);
+}


### PR DESCRIPTION
## Summary
- expose `getNextMonth` helper in date utils
- auto-fill next month's electric bill details and clear inputs on save
- show success messages after saving bills

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c17f0f43883238b7fc1f0759fc63c