### PR TITLE
Add payroll history feature

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ import BillHistoryPage from './pages/BillHistoryPage';
 import AdvanceHistoryPage from './pages/AdvanceHistoryPage';
 import SavingsHistoryPage from './pages/SavingsHistoryPage';
 import PayrollPage from './pages/PayrollPage';
+import PayrollHistoryPage from './pages/PayrollHistoryPage';
 
 
 // --- Main App Component ---
@@ -101,6 +102,7 @@ function AppContent() {
           <Route path="/admin/advance-history" element={<AdvanceHistoryPage />} />
           <Route path="/admin/savings-history" element={<SavingsHistoryPage />} />
           <Route path="/admin/payroll" element={<PayrollPage />} />
+          <Route path="/admin/payroll-history" element={<PayrollHistoryPage />} />
           <Route path="/admin/history" element={<WorkHistoryPage />} />
           <Route element={<SuperuserRoute />}>
             <Route path="/admin/create-admin" element={<AdminCreatePage />} />

--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -19,6 +19,7 @@ const AdminNavbar = ({ adminUser, onLogout }) => {
           <Link to="/admin/savings-history" className="hover:text-gray-300">ประวัติเงินเก็บ</Link>
           <Link to="/admin/bill-history" className="hover:text-gray-300">ประวัติค่าน้ำไฟ</Link>
           <Link to="/admin/payroll" className="hover:text-gray-300">จ่ายเงินเดือน</Link>
+          <Link to="/admin/payroll-history" className="hover:text-gray-300">ประวัติเงินเดือน</Link>
           {adminUser && adminUser.is_superuser && (
             <>
               <Link to="/admin/create-admin" className="hover:text-gray-300">สร้างบัญชี Admin</Link>

--- a/client/src/pages/AttendanceReviewPage.jsx
+++ b/client/src/pages/AttendanceReviewPage.jsx
@@ -19,6 +19,7 @@ function AttendanceReviewPage() {
       const res = await axios.get('/api/attendance/pending');
       setForms(res.data);
     } catch (err) {
+      console.error(err);
       setError('ไม่สามารถโหลดข้อมูลได้');
     }
   };
@@ -54,6 +55,7 @@ function AttendanceReviewPage() {
       await axios.put(`/api/attendance/${id}/verify`, { isBonus });
       fetchForms();
     } catch (err) {
+      console.error(err);
       alert('เกิดข้อผิดพลาดในการยืนยัน');
     }
   };
@@ -64,6 +66,7 @@ function AttendanceReviewPage() {
       await axios.delete(`/api/attendance/${id}`);
       fetchForms();
     } catch (err) {
+      console.error(err);
       alert('เกิดข้อผิดพลาดในการลบ');
     }
   };
@@ -140,10 +143,11 @@ function AttendanceReviewPage() {
       setEditingForm(null);
       setEditData(null);
       fetchForms();
-    } catch (err) {
-      alert('บันทึกไม่สำเร็จ');
-    }
-  };
+      } catch (err) {
+        console.error(err);
+        alert('บันทึกไม่สำเร็จ');
+      }
+    };
 
   return (
     <div className="p-6 max-w-6xl mx-auto text-black">

--- a/client/src/pages/AttendanceVerificationPage.jsx
+++ b/client/src/pages/AttendanceVerificationPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import { Link } from 'react-router-dom';
 
 // --- Helper Components ---
@@ -14,7 +13,6 @@ function AttendanceVerificationPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [filterDate, setFilterDate] = useState(new Date().toISOString().slice(0, 10));
-  const [editingSubmission, setEditingSubmission] = useState(null); // State to hold submission being edited
 
   useEffect(() => {
     fetchSubmissions(filterDate);
@@ -97,7 +95,6 @@ function AttendanceVerificationPage() {
     // For a real app, you would probably open a modal with a form similar to AttendancePage
     // and populate it with the 'submission' data.
     alert(`ฟังก์ชั่นแก้ไขสำหรับรายการ #${submission.submission_id} (ยังไม่ได้ทำ)\nในแอปจริง ส่วนนี้จะเปิด Modal หรือฟอร์มให้แก้ไขข้อมูล`);
-    setEditingSubmission(submission); // Example of setting state for an editing modal
   };
 
   return (

--- a/client/src/pages/PayrollHistoryPage.jsx
+++ b/client/src/pages/PayrollHistoryPage.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function PayrollHistoryPage() {
+  const [cycle, setCycle] = useState('รายเดือน');
+  const [month, setMonth] = useState(new Date().toISOString().slice(0, 7));
+  const [records, setRecords] = useState([]);
+  const [error, setError] = useState('');
+
+  const fetchHistory = async (m, c) => {
+    try {
+      if (c === 'รายเดือน') {
+        const res = await axios.get(`/api/payroll/monthly/history?month=${m}`);
+        setRecords(res.data);
+      } else {
+        const res = await axios.get(`/api/payroll/semi-monthly/history?month=${m}`);
+        setRecords(res.data);
+      }
+    } catch (err) {
+      console.error(err);
+      setError('ไม่สามารถโหลดข้อมูล');
+    }
+  };
+
+  useEffect(() => {
+    fetchHistory(month, cycle);
+  }, [cycle, month]);
+
+  const renderTable = () => (
+    <table className="min-w-full bg-white shadow rounded text-sm">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="px-2 py-2">รหัส</th>
+          <th className="px-2 py-2 text-left">ชื่อพนักงาน</th>
+          {cycle === 'ครึ่งเดือน' && <th className="px-2 py-2">รอบ</th>}
+          <th className="px-2 py-2">วันทำงาน</th>
+          <th className="px-2 py-2">ชั่วโมง</th>
+          <th className="px-2 py-2">เบี้ยขยัน</th>
+          <th className="px-2 py-2">ค่าแรงรวม</th>
+          <th className="px-2 py-2">OT(ชม.)</th>
+          <th className="px-2 py-2">ค่า OT</th>
+          <th className="px-2 py-2">อาทิตย์(วัน)</th>
+          <th className="px-2 py-2">ค่าอาทิตย์</th>
+          <th className="px-2 py-2">รวมรายได้</th>
+          <th className="px-2 py-2">ค่าน้ำ</th>
+          <th className="px-2 py-2">ค่าไฟ</th>
+          <th className="px-2 py-2">หักอื่นๆ</th>
+          <th className="px-2 py-2">รวมยอดหัก</th>
+          <th className="px-2 py-2">รับสุทธิ</th>
+        </tr>
+      </thead>
+      <tbody>
+        {records.map((p) => (
+          <tr key={`${p.employee_id}-${p.period || 'm'}`} className="border-t">
+            <td className="px-2 py-1 text-center">{p.employee_id}</td>
+            <td className="px-2 py-1">{`${p.first_name} ${p.last_name}`}</td>
+            {cycle === 'ครึ่งเดือน' && (
+              <td className="px-2 py-1 text-center">
+                {p.period === 'first' ? '1-15' : '16-สิ้นเดือน'}
+              </td>
+            )}
+            <td className="px-2 py-1 text-center">{p.days_worked}</td>
+            <td className="px-2 py-1 text-center">{p.hours_worked}</td>
+            <td className="px-2 py-1 text-center">{p.bonus_count}</td>
+            <td className="px-2 py-1 text-right">{Number(p.base_pay).toFixed(2)}</td>
+            <td className="px-2 py-1 text-center">{p.ot_hours}</td>
+            <td className="px-2 py-1 text-right">{Number(p.ot_pay).toFixed(2)}</td>
+            <td className="px-2 py-1 text-center">{p.sunday_days}</td>
+            <td className="px-2 py-1 text-right">{Number(p.sunday_pay).toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{Number(p.total_income).toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{Number(p.water_deduction).toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{Number(p.electric_deduction).toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{Number(p.other_deductions).toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{Number(p.deductions_total).toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{Number(p.net_pay).toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  return (
+    <div className="p-6 text-black space-y-6">
+      <h2 className="text-2xl font-semibold">ประวัติเงินเดือน</h2>
+      {error && <div className="text-red-600">{error}</div>}
+      <div className="mb-4">
+        <label className="mr-2 font-semibold">รอบจ่าย</label>
+        <select value={cycle} onChange={(e) => setCycle(e.target.value)} className="border p-2">
+          <option value="รายเดือน">รายเดือน</option>
+          <option value="ครึ่งเดือน">ครึ่งเดือน</option>
+        </select>
+      </div>
+      <div className="mb-4">
+        <label className="mr-2 font-semibold">เดือน</label>
+        <input type="month" value={month} onChange={(e) => setMonth(e.target.value)} className="border p-2" />
+      </div>
+      {records.length > 0 ? renderTable() : <p className="text-red-500">ไม่พบข้อมูล</p>}
+    </div>
+  );
+}
+
+export default PayrollHistoryPage;

--- a/client/src/pages/PayrollPage.jsx
+++ b/client/src/pages/PayrollPage.jsx
@@ -2,44 +2,125 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 
 function PayrollPage() {
-  const [employees, setEmployees] = useState([]);
+  const [payroll, setPayroll] = useState([]);
   const [error, setError] = useState('');
   const [cycle, setCycle] = useState('รายเดือน');
+  const [month, setMonth] = useState(new Date().toISOString().slice(0, 7));
+  const [halfPeriod, setHalfPeriod] = useState('1-15');
 
-  const fetchEmployees = async (selectedCycle) => {
+
+  const fetchPayroll = async (m) => {
     try {
-      const res = await axios.get(`/api/employees/cycle/${selectedCycle}`);
-      setEmployees(res.data);
+      const res = await axios.get(`/api/payroll/monthly?month=${m}`);
+      const sorted = res.data.sort((a, b) => {
+        if (a.nationality === 'ไทย' && b.nationality !== 'ไทย') return -1;
+        if (a.nationality !== 'ไทย' && b.nationality === 'ไทย') return 1;
+        return a.employee_id - b.employee_id;
+      });
+      setPayroll(sorted);
     } catch (err) {
       console.error(err);
-      setError('ไม่สามารถโหลดข้อมูลพนักงาน');
+      setError('ไม่สามารถโหลดข้อมูลเงินเดือน');
+    }
+  };
+
+  const fetchSemiPayroll = async (m, period) => {
+    try {
+      const p = period === '16-สิ้นเดือน' ? 'second' : 'first';
+      const res = await axios.get(`/api/payroll/semi-monthly?month=${m}&period=${p}`);
+      const sorted = res.data.sort((a, b) => {
+        if (a.nationality === 'ไทย' && b.nationality !== 'ไทย') return -1;
+        if (a.nationality !== 'ไทย' && b.nationality === 'ไทย') return 1;
+        return a.employee_id - b.employee_id;
+      });
+      setPayroll(sorted);
+    } catch (err) {
+      console.error(err);
+      setError('ไม่สามารถโหลดข้อมูลเงินเดือน');
     }
   };
 
   useEffect(() => {
-    fetchEmployees(cycle);
-  }, [cycle]);
+    if (cycle === 'รายเดือน') {
+      fetchPayroll(month);
+    } else {
+      fetchSemiPayroll(month, halfPeriod);
+    }
+  }, [cycle, month, halfPeriod]);
 
-  const renderTable = emps => (
-    <table className="min-w-full bg-white shadow rounded">
+
+  const handleConfirm = async (id) => {
+    try {
+      if (cycle === 'รายเดือน') {
+        await axios.post('/api/payroll/monthly/record', { employeeId: id, month });
+      } else {
+        const p = halfPeriod === '16-สิ้นเดือน' ? 'second' : 'first';
+        await axios.post('/api/payroll/semi-monthly/record', { employeeId: id, month, period: p });
+      }
+      alert('บันทึกสำเร็จ');
+    } catch (err) {
+      console.error(err);
+      alert('บันทึกไม่สำเร็จ');
+    }
+  };
+
+  const renderPayrollTable = (data, showDeduction = true) => (
+    <table className="min-w-full bg-white shadow rounded text-sm">
       <thead className="bg-gray-100">
         <tr>
-          <th className="px-4 py-2 text-left">รหัส</th>
-          <th className="px-4 py-2 text-left">ชื่อพนักงาน</th>
-          <th className="px-4 py-2 text-left">ค่าแรง/วัน</th>
-          <th className="px-4 py-2 text-left">เงินเดือนประมาณ</th>
+          <th className="px-2 py-2">รหัส</th>
+          <th className="px-2 py-2 text-left">ชื่อพนักงาน</th>
+          <th className="px-2 py-2">วันทำงาน</th>
+          <th className="px-2 py-2">ชั่วโมง</th>
+          <th className="px-2 py-2">เบี้ยขยัน</th>
+          <th className="px-2 py-2">ค่าแรงรวม</th>
+          <th className="px-2 py-2">OT(ชม.)</th>
+          <th className="px-2 py-2">ค่า OT</th>
+          <th className="px-2 py-2">อาทิตย์(วัน)</th>
+          <th className="px-2 py-2">ค่าอาทิตย์</th>
+          <th className="px-2 py-2">รวมรายได้</th>
+          {showDeduction && <th className="px-2 py-2">ค่าน้ำ</th>}
+          {showDeduction && <th className="px-2 py-2">ค่าไฟ</th>}
+          {showDeduction && <th className="px-2 py-2">หักอื่นๆ</th>}
+          {showDeduction && <th className="px-2 py-2">รวมยอดหัก</th>}
+          <th className="px-2 py-2">รับสุทธิ</th>
+          <th className="px-2 py-2" />
         </tr>
       </thead>
       <tbody>
-        {emps.map(e => (
-          <tr key={e.id} className="border-t">
-            <td className="px-4 py-2">{e.employee_code || e.id}</td>
-            <td className="px-4 py-2">{e.first_name} {e.last_name}</td>
-            <td className="px-4 py-2 text-right">{parseFloat(e.daily_wage).toFixed(2)}</td>
-            <td className="px-4 py-2 text-right">
-              {e.payment_cycle === 'รายเดือน'
-                ? (e.daily_wage * 30).toFixed(2)
-                : (e.daily_wage * 15).toFixed(2)}
+        {data.map((p) => (
+          <tr key={p.employee_id} className="border-t">
+            <td className="px-2 py-1 text-center">{p.employee_id}</td>
+            <td className="px-2 py-1">{p.name}</td>
+            <td className="px-2 py-1 text-center">{p.days_worked}</td>
+            <td className="px-2 py-1 text-center">{p.hours_worked}</td>
+            <td className="px-2 py-1 text-center">{p.bonus_count}</td>
+            <td className="px-2 py-1 text-right">{p.base_pay.toFixed(2)}</td>
+            <td className="px-2 py-1 text-center">{p.ot_hours}</td>
+            <td className="px-2 py-1 text-right">{p.ot_pay.toFixed(2)}</td>
+            <td className="px-2 py-1 text-center">{p.sunday_days}</td>
+            <td className="px-2 py-1 text-right">{p.sunday_pay.toFixed(2)}</td>
+            <td className="px-2 py-1 text-right">{p.total_income.toFixed(2)}</td>
+            {showDeduction && (
+              <td className="px-2 py-1 text-right">{p.water_deduction.toFixed(2)}</td>
+            )}
+            {showDeduction && (
+              <td className="px-2 py-1 text-right">{p.electric_deduction.toFixed(2)}</td>
+            )}
+            {showDeduction && (
+              <td className="px-2 py-1 text-right">{p.other_deductions.toFixed(2)}</td>
+            )}
+            {showDeduction && (
+              <td className="px-2 py-1 text-right">{p.deductions_total.toFixed(2)}</td>
+            )}
+            <td className="px-2 py-1 text-right">{p.net_pay.toFixed(2)}</td>
+            <td className="px-2 py-1 text-center">
+              <button
+                onClick={() => handleConfirm(p.employee_id)}
+                className="bg-blue-500 hover:bg-blue-600 text-white px-2 py-1 rounded"
+              >
+                ยืนยันบิล
+              </button>
             </td>
           </tr>
         ))}
@@ -63,11 +144,36 @@ function PayrollPage() {
           <option value="ครึ่งเดือน">ครึ่งเดือน</option>
         </select>
       </div>
+      {(cycle === 'รายเดือน' || cycle === 'ครึ่งเดือน') && (
+        <div className="mb-4">
+          <label className="mr-2 font-semibold">เดือน</label>
+          <input
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="border p-2"
+          />
+        </div>
+      )}
 
-      {employees.length > 0 ? (
-        renderTable(employees)
+      {cycle === 'ครึ่งเดือน' && (
+        <div className="mb-4">
+          <label className="mr-2 font-semibold">รอบ</label>
+          <select
+            value={halfPeriod}
+            onChange={(e) => setHalfPeriod(e.target.value)}
+            className="border p-2"
+          >
+            <option value="1-15">1-15</option>
+            <option value="16-สิ้นเดือน">16-สิ้นเดือน</option>
+          </select>
+        </div>
+      )}
+
+      {payroll.length > 0 ? (
+        renderPayrollTable(payroll, cycle === 'รายเดือน' || halfPeriod === '16-สิ้นเดือน')
       ) : (
-        <p className="text-red-500">ไม่พบข้อมูลพนักงานรอบจ่าย{cycle}</p>
+        <p className="text-red-500">ไม่พบข้อมูลเงินเดือน</p>
       )}
     </div>
   );

--- a/client/src/pages/WorkHistoryPage.jsx
+++ b/client/src/pages/WorkHistoryPage.jsx
@@ -11,6 +11,7 @@ function WorkHistoryPage() {
       const res = await axios.get('/api/attendance/history');
       setForms(res.data);
     } catch (err) {
+      console.error(err);
       setError('ไม่สามารถโหลดข้อมูลได้');
     }
   };

--- a/server/db_schema.sql
+++ b/server/db_schema.sql
@@ -145,3 +145,50 @@ CREATE TABLE IF NOT EXISTS SavingsTransactions (
     remark TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Monthly payroll records
+CREATE TABLE IF NOT EXISTS PayrollRecords (
+    id SERIAL PRIMARY KEY,
+    employee_id INTEGER REFERENCES Employees(id) ON DELETE CASCADE,
+    pay_month DATE NOT NULL,
+    days_worked NUMERIC(5,2) DEFAULT 0,
+    hours_worked NUMERIC(5,2) DEFAULT 0,
+    bonus_count INTEGER DEFAULT 0,
+    ot_hours NUMERIC(5,2) DEFAULT 0,
+    sunday_days NUMERIC(5,2) DEFAULT 0,
+    base_pay NUMERIC(12,2) DEFAULT 0,
+    ot_pay NUMERIC(12,2) DEFAULT 0,
+    sunday_pay NUMERIC(12,2) DEFAULT 0,
+    water_deduction NUMERIC(12,2) DEFAULT 0,
+    electric_deduction NUMERIC(12,2) DEFAULT 0,
+    other_deductions NUMERIC(12,2) DEFAULT 0,
+    deductions_total NUMERIC(12,2) DEFAULT 0,
+    total_income NUMERIC(12,2) DEFAULT 0,
+    net_pay NUMERIC(12,2) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(employee_id, pay_month)
+);
+
+-- Semi-monthly payroll records
+CREATE TABLE IF NOT EXISTS HalfPayrollRecords (
+    id SERIAL PRIMARY KEY,
+    employee_id INTEGER REFERENCES Employees(id) ON DELETE CASCADE,
+    pay_month DATE NOT NULL,
+    period VARCHAR(10) NOT NULL,
+    days_worked NUMERIC(5,2) DEFAULT 0,
+    hours_worked NUMERIC(5,2) DEFAULT 0,
+    bonus_count INTEGER DEFAULT 0,
+    ot_hours NUMERIC(5,2) DEFAULT 0,
+    sunday_days NUMERIC(5,2) DEFAULT 0,
+    base_pay NUMERIC(12,2) DEFAULT 0,
+    ot_pay NUMERIC(12,2) DEFAULT 0,
+    sunday_pay NUMERIC(12,2) DEFAULT 0,
+    water_deduction NUMERIC(12,2) DEFAULT 0,
+    electric_deduction NUMERIC(12,2) DEFAULT 0,
+    other_deductions NUMERIC(12,2) DEFAULT 0,
+    deductions_total NUMERIC(12,2) DEFAULT 0,
+    total_income NUMERIC(12,2) DEFAULT 0,
+    net_pay NUMERIC(12,2) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(employee_id, pay_month, period)
+);

--- a/server/src/controllers/payrollController.js
+++ b/server/src/controllers/payrollController.js
@@ -1,0 +1,441 @@
+const pool = require('../config/db');
+
+function calcWorkTime(checkIn, checkOut) {
+  if (!checkIn || !checkOut) return { days: 0, hours: 0 };
+  const start = new Date(`1970-01-01T${checkIn}Z`);
+  const end = new Date(`1970-01-01T${checkOut}Z`);
+  let diff = (end - start) / 3600000;
+  if (checkIn <= '12:00:00' && checkOut >= '13:00:00') diff -= 1;
+  if (diff >= 8) return { days: 1, hours: diff - 8 };
+  if (diff >= 4) return { days: 0.5, hours: diff - 4 };
+  return { days: 0, hours: diff };
+}
+
+async function calculateRange(emp, startDate, endDate) {
+  let days = 0;
+  let hours = 0;
+  let bonus = 0;
+  let otHours = 0;
+  let sunDays = 0;
+
+  const { rows: att } = await pool.query(
+    `SELECT a.attendance_date, a.site_supervisor_id, a.supervisor_ot, a.is_sunday, a.is_bonus,
+            ae.check_in, ae.check_out, ae.ot_hours
+       FROM AttendanceForms a
+       LEFT JOIN AttendanceEmployees ae ON a.id = ae.attendance_id AND ae.employee_id=$3
+      WHERE a.is_verified=true
+        AND a.attendance_date >= $1 AND a.attendance_date < $2
+        AND (ae.id IS NOT NULL OR a.site_supervisor_id=$3)`,
+    [startDate, endDate, emp.id]
+  );
+
+  for (const r of att) {
+    if (r.check_in && r.check_out) {
+      const w = calcWorkTime(r.check_in, r.check_out);
+      days += w.days;
+      hours += w.hours;
+    }
+    if (r.is_bonus) bonus += 1;
+    if (r.ot_hours) otHours += parseFloat(r.ot_hours);
+    if (r.site_supervisor_id === emp.id && r.supervisor_ot) {
+      otHours += parseFloat(r.supervisor_ot);
+    }
+    if (r.is_sunday) sunDays += 1;
+  }
+
+  const daily = parseFloat(emp.daily_wage);
+  const basePay = days * daily + hours * (daily / 8) + bonus * 50;
+  const otRate = (daily / 8) * 1.5;
+  const otPay = otHours * otRate;
+  const sunRate = daily * 1.5;
+  const sunPay = sunDays * sunRate;
+  const totalIncome = basePay + otPay + sunPay;
+
+  return {
+    days,
+    hours: parseFloat(hours.toFixed(2)),
+    bonus,
+    otHours: parseFloat(otHours.toFixed(2)),
+    sunDays,
+    basePay: parseFloat(basePay.toFixed(2)),
+    otPay: parseFloat(otPay.toFixed(2)),
+    sunPay: parseFloat(sunPay.toFixed(2)),
+    totalIncome: parseFloat(totalIncome.toFixed(2)),
+  };
+}
+
+async function calcWaterDed(emp, month) {
+  if (!emp.water_address) return 0;
+  const { rows: bill } = await pool.query(
+    'SELECT water_charge FROM WaterBills WHERE address_name=$1 AND bill_month=$2',
+    [emp.water_address, month]
+  );
+  if (!bill.length) return 0;
+  const charge = parseFloat(bill[0].water_charge);
+  const { rows: cnt } = await pool.query(
+    'SELECT COUNT(*) FROM Employees WHERE water_address=$1',
+    [emp.water_address]
+  );
+  const people = parseInt(cnt[0].count) || 0;
+  return people >= 0 ? charge / (people + 3) : 0;
+}
+
+async function calcElectricDed(emp, month) {
+  if (!emp.electric_address) return 0;
+  const { rows: bill } = await pool.query(
+    'SELECT last_unit, current_unit FROM ElectricBills WHERE address_name=$1 AND bill_month=$2',
+    [emp.electric_address, month]
+  );
+  if (!bill.length) return 0;
+  const usage = parseFloat(bill[0].current_unit) - parseFloat(bill[0].last_unit);
+  const charge = usage * 5;
+  const { rows: cnt } = await pool.query(
+    'SELECT COUNT(*) FROM Employees WHERE electric_address=$1',
+    [emp.electric_address]
+  );
+  const people = parseInt(cnt[0].count) || 0;
+  return people > 0 ? charge / people : 0;
+}
+
+exports.getMonthlyPayroll = async (req, res) => {
+  const month = req.query.month || new Date().toISOString().slice(0, 7);
+  const monthStart = new Date(`${month}-01`);
+  const monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 1);
+
+  try {
+    const { rows: employees } = await pool.query(
+      "SELECT * FROM Employees WHERE payment_cycle='รายเดือน' ORDER BY id"
+    );
+    const { rows: deductionTypes } = await pool.query(
+      'SELECT name, rate FROM DeductionTypes WHERE is_active=true ORDER BY id'
+    );
+    const result = [];
+
+    for (const emp of employees) {
+      const details = await calculateRange(emp, monthStart, monthEnd);
+      const waterDed = await calcWaterDed(emp, `${month}-01`);
+      const electricDed = await calcElectricDed(emp, `${month}-01`);
+
+      let otherDed = 0;
+      const deductionDetails = [];
+      const baseForDeduction = details.basePay + details.otPay;
+      for (const d of deductionTypes) {
+        const rate = parseFloat(d.rate) || 0;
+        const amount = (baseForDeduction * rate) / 100;
+        otherDed += amount;
+        deductionDetails.push({ name: d.name, amount: parseFloat(amount.toFixed(2)) });
+      }
+
+      const deductionsTotal = waterDed + electricDed + otherDed;
+      const netPay = details.totalIncome - deductionsTotal;
+
+      result.push({
+        employee_id: emp.id,
+        name: `${emp.first_name} ${emp.last_name}`,
+        nationality: emp.nationality,
+        days_worked: details.days,
+        hours_worked: details.hours,
+        bonus_count: details.bonus,
+        base_pay: details.basePay,
+        ot_hours: details.otHours,
+        ot_pay: details.otPay,
+        sunday_days: details.sunDays,
+        sunday_pay: details.sunPay,
+        total_income: details.totalIncome,
+        water_deduction: parseFloat(waterDed.toFixed(2)),
+        electric_deduction: parseFloat(electricDed.toFixed(2)),
+        other_deductions: parseFloat(otherDed.toFixed(2)),
+        deductions_total: parseFloat(deductionsTotal.toFixed(2)),
+        net_pay: parseFloat(netPay.toFixed(2)),
+        deduction_details: deductionDetails,
+      });
+    }
+
+    res.json(result);
+  } catch (err) {
+    console.error('Error in getMonthlyPayroll:', err.message);
+    res.status(500).send('Server error while calculating payroll');
+  }
+};
+
+exports.getSemiMonthlyPayroll = async (req, res) => {
+  const month = req.query.month || new Date().toISOString().slice(0, 7);
+  const period = req.query.period === 'second' ? 'second' : 'first';
+  const monthStart = new Date(`${month}-01`);
+  const midDate = new Date(monthStart.getFullYear(), monthStart.getMonth(), 16);
+  const monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 1);
+
+  const rangeStart = period === 'first' ? monthStart : midDate;
+  const rangeEnd = period === 'first' ? midDate : monthEnd;
+
+  try {
+    const { rows: employees } = await pool.query(
+      "SELECT * FROM Employees WHERE payment_cycle='ครึ่งเดือน' ORDER BY id"
+    );
+    const { rows: deductionTypes } = await pool.query(
+      'SELECT name, rate FROM DeductionTypes WHERE is_active=true ORDER BY id'
+    );
+    const result = [];
+
+    for (const emp of employees) {
+      const monthly = await calculateRange(emp, monthStart, monthEnd);
+      const part = await calculateRange(emp, rangeStart, rangeEnd);
+
+      const waterDed = await calcWaterDed(emp, `${month}-01`);
+      const electricDed = await calcElectricDed(emp, `${month}-01`);
+
+      let otherDed = 0;
+      const deductionDetails = [];
+      const baseForDeduction = monthly.basePay + monthly.otPay;
+      for (const d of deductionTypes) {
+        const rate = parseFloat(d.rate) || 0;
+        const amount = (baseForDeduction * rate) / 100;
+        otherDed += amount;
+        deductionDetails.push({ name: d.name, amount: parseFloat(amount.toFixed(2)) });
+      }
+
+      const deductionsTotal = period === 'second' ? waterDed + electricDed + otherDed : 0;
+      const netPay = part.totalIncome - deductionsTotal;
+
+      result.push({
+        employee_id: emp.id,
+        name: `${emp.first_name} ${emp.last_name}`,
+        nationality: emp.nationality,
+        period,
+        days_worked: part.days,
+        hours_worked: part.hours,
+        bonus_count: part.bonus,
+        base_pay: part.basePay,
+        ot_hours: part.otHours,
+        ot_pay: part.otPay,
+        sunday_days: part.sunDays,
+        sunday_pay: part.sunPay,
+        total_income: part.totalIncome,
+        water_deduction: parseFloat(waterDed.toFixed(2)),
+        electric_deduction: parseFloat(electricDed.toFixed(2)),
+        other_deductions: parseFloat(otherDed.toFixed(2)),
+        deductions_total: parseFloat(deductionsTotal.toFixed(2)),
+        net_pay: parseFloat(netPay.toFixed(2)),
+        deduction_details: deductionDetails,
+      });
+    }
+
+    res.json(result);
+  } catch (err) {
+    console.error('Error in getSemiMonthlyPayroll:', err.message);
+    res.status(500).send('Server error while calculating semimonthly payroll');
+  }
+};
+
+exports.recordMonthlyPayroll = async (req, res) => {
+  const { employeeId, month } = req.body;
+  const payMonth = month || new Date().toISOString().slice(0, 7);
+  const monthStart = new Date(`${payMonth}-01`);
+  const monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 1);
+
+  try {
+    const empRes = await pool.query('SELECT * FROM Employees WHERE id=$1', [employeeId]);
+    if (!empRes.rows.length) return res.status(404).json({ msg: 'Employee not found' });
+    const emp = empRes.rows[0];
+    const { rows: deductionTypes } = await pool.query(
+      'SELECT name, rate FROM DeductionTypes WHERE is_active=true ORDER BY id'
+    );
+
+    const details = await calculateRange(emp, monthStart, monthEnd);
+    const waterDed = await calcWaterDed(emp, `${payMonth}-01`);
+    const electricDed = await calcElectricDed(emp, `${payMonth}-01`);
+
+    let otherDed = 0;
+    for (const d of deductionTypes) {
+      const rate = parseFloat(d.rate) || 0;
+      const amount = ((details.basePay + details.otPay) * rate) / 100;
+      otherDed += amount;
+    }
+
+    const deductionsTotal = waterDed + electricDed + otherDed;
+    const netPay = details.totalIncome - deductionsTotal;
+
+    await pool.query(
+      `INSERT INTO PayrollRecords (
+        employee_id, pay_month, days_worked, hours_worked, bonus_count,
+        ot_hours, sunday_days, base_pay, ot_pay, sunday_pay,
+        water_deduction, electric_deduction, other_deductions, deductions_total,
+        total_income, net_pay
+      ) VALUES (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16
+      )
+      ON CONFLICT (employee_id, pay_month)
+      DO UPDATE SET
+        days_worked=EXCLUDED.days_worked,
+        hours_worked=EXCLUDED.hours_worked,
+        bonus_count=EXCLUDED.bonus_count,
+        ot_hours=EXCLUDED.ot_hours,
+        sunday_days=EXCLUDED.sunday_days,
+        base_pay=EXCLUDED.base_pay,
+        ot_pay=EXCLUDED.ot_pay,
+        sunday_pay=EXCLUDED.sunday_pay,
+        water_deduction=EXCLUDED.water_deduction,
+        electric_deduction=EXCLUDED.electric_deduction,
+        other_deductions=EXCLUDED.other_deductions,
+        deductions_total=EXCLUDED.deductions_total,
+        total_income=EXCLUDED.total_income,
+        net_pay=EXCLUDED.net_pay`,
+      [
+        emp.id,
+        `${payMonth}-01`,
+        details.days,
+        details.hours,
+        details.bonus,
+        details.otHours,
+        details.sunDays,
+        details.basePay,
+        details.otPay,
+        details.sunPay,
+        parseFloat(waterDed.toFixed(2)),
+        parseFloat(electricDed.toFixed(2)),
+        parseFloat(otherDed.toFixed(2)),
+        parseFloat(deductionsTotal.toFixed(2)),
+        details.totalIncome,
+        parseFloat(netPay.toFixed(2)),
+      ]
+    );
+
+    res.json({ msg: 'recorded' });
+  } catch (err) {
+    console.error('Error in recordMonthlyPayroll:', err.message);
+    res.status(500).send('Server error while recording payroll');
+  }
+};
+
+exports.recordSemiMonthlyPayroll = async (req, res) => {
+  const { employeeId, month, period } = req.body;
+  const payMonth = month || new Date().toISOString().slice(0, 7);
+  const per = period === 'second' ? 'second' : 'first';
+  const monthStart = new Date(`${payMonth}-01`);
+  const midDate = new Date(monthStart.getFullYear(), monthStart.getMonth(), 16);
+  const monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 1);
+  const rangeStart = per === 'first' ? monthStart : midDate;
+  const rangeEnd = per === 'first' ? midDate : monthEnd;
+
+  try {
+    const empRes = await pool.query('SELECT * FROM Employees WHERE id=$1', [employeeId]);
+    if (!empRes.rows.length) return res.status(404).json({ msg: 'Employee not found' });
+    const emp = empRes.rows[0];
+    const { rows: deductionTypes } = await pool.query(
+      'SELECT name, rate FROM DeductionTypes WHERE is_active=true ORDER BY id'
+    );
+
+    const monthly = await calculateRange(emp, monthStart, monthEnd);
+    const part = await calculateRange(emp, rangeStart, rangeEnd);
+    const waterDed = await calcWaterDed(emp, `${payMonth}-01`);
+    const electricDed = await calcElectricDed(emp, `${payMonth}-01`);
+
+    let otherDed = 0;
+    for (const d of deductionTypes) {
+      const rate = parseFloat(d.rate) || 0;
+      const amount = ((monthly.basePay + monthly.otPay) * rate) / 100;
+      otherDed += amount;
+    }
+
+    const deductionsTotal = per === 'second' ? waterDed + electricDed + otherDed : 0;
+    const netPay = part.totalIncome - deductionsTotal;
+
+    await pool.query(
+      `INSERT INTO HalfPayrollRecords (
+        employee_id, pay_month, period, days_worked, hours_worked, bonus_count,
+        ot_hours, sunday_days, base_pay, ot_pay, sunday_pay,
+        water_deduction, electric_deduction, other_deductions, deductions_total,
+        total_income, net_pay
+      ) VALUES (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17
+      )
+      ON CONFLICT (employee_id, pay_month, period)
+      DO UPDATE SET
+        days_worked=EXCLUDED.days_worked,
+        hours_worked=EXCLUDED.hours_worked,
+        bonus_count=EXCLUDED.bonus_count,
+        ot_hours=EXCLUDED.ot_hours,
+        sunday_days=EXCLUDED.sunday_days,
+        base_pay=EXCLUDED.base_pay,
+        ot_pay=EXCLUDED.ot_pay,
+        sunday_pay=EXCLUDED.sunday_pay,
+        water_deduction=EXCLUDED.water_deduction,
+        electric_deduction=EXCLUDED.electric_deduction,
+        other_deductions=EXCLUDED.other_deductions,
+        deductions_total=EXCLUDED.deductions_total,
+        total_income=EXCLUDED.total_income,
+        net_pay=EXCLUDED.net_pay`,
+      [
+        emp.id,
+        `${payMonth}-01`,
+        per,
+        part.days,
+        part.hours,
+        part.bonus,
+        part.otHours,
+        part.sunDays,
+        part.basePay,
+        part.otPay,
+        part.sunPay,
+        parseFloat(waterDed.toFixed(2)),
+        parseFloat(electricDed.toFixed(2)),
+        parseFloat(otherDed.toFixed(2)),
+        parseFloat(deductionsTotal.toFixed(2)),
+        part.totalIncome,
+        parseFloat(netPay.toFixed(2)),
+      ]
+    );
+
+    res.json({ msg: 'recorded' });
+  } catch (err) {
+    console.error('Error in recordSemiMonthlyPayroll:', err.message);
+    res.status(500).send('Server error while recording semimonthly payroll');
+  }
+};
+
+exports.getMonthlyHistory = async (req, res) => {
+  const month = req.query.month || new Date().toISOString().slice(0, 7);
+  try {
+    const { rows } = await pool.query(
+      `SELECT p.*, e.first_name, e.last_name, e.nationality
+       FROM PayrollRecords p
+       JOIN Employees e ON p.employee_id = e.id
+       WHERE to_char(p.pay_month, 'YYYY-MM') = $1`,
+      [month]
+    );
+    rows.sort((a, b) => {
+      if (a.nationality === 'ไทย' && b.nationality !== 'ไทย') return -1;
+      if (a.nationality !== 'ไทย' && b.nationality === 'ไทย') return 1;
+      return a.employee_id - b.employee_id;
+    });
+    res.json(rows);
+  } catch (err) {
+    console.error('Error in getMonthlyHistory:', err.message);
+    res.status(500).send('Server error while fetching payroll history');
+  }
+};
+
+exports.getSemiMonthlyHistory = async (req, res) => {
+  const month = req.query.month || new Date().toISOString().slice(0, 7);
+  try {
+    const { rows } = await pool.query(
+      `SELECT h.*, e.first_name, e.last_name, e.nationality
+       FROM HalfPayrollRecords h
+       JOIN Employees e ON h.employee_id = e.id
+       WHERE to_char(h.pay_month, 'YYYY-MM') = $1`,
+      [month]
+    );
+    rows.sort((a, b) => {
+      if (a.nationality === 'ไทย' && b.nationality !== 'ไทย') return -1;
+      if (a.nationality !== 'ไทย' && b.nationality === 'ไทย') return 1;
+      if (a.employee_id === b.employee_id) {
+        return a.period === b.period ? 0 : a.period === 'first' ? -1 : 1;
+      }
+      return a.employee_id - b.employee_id;
+    });
+    res.json(rows);
+  } catch (err) {
+    console.error('Error in getSemiMonthlyHistory:', err.message);
+    res.status(500).send('Server error while fetching semimonthly history');
+  }
+};

--- a/server/src/routes/payrollRoutes.js
+++ b/server/src/routes/payrollRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const payrollController = require('../controllers/payrollController');
+const authMiddleware = require('../middleware/authMiddleware');
+
+router.get('/monthly', authMiddleware, payrollController.getMonthlyPayroll);
+router.get('/semi-monthly', authMiddleware, payrollController.getSemiMonthlyPayroll);
+router.post('/monthly/record', authMiddleware, payrollController.recordMonthlyPayroll);
+router.post('/semi-monthly/record', authMiddleware, payrollController.recordSemiMonthlyPayroll);
+router.get('/monthly/history', authMiddleware, payrollController.getMonthlyHistory);
+router.get('/semi-monthly/history', authMiddleware, payrollController.getSemiMonthlyHistory);
+
+module.exports = router;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -28,6 +28,7 @@ app.use('/api/deductions', require('./routes/deductionRoutes'));
 app.use('/api/advances', require('./routes/advanceRoutes'));
 app.use('/api/savings', require('./routes/savingsRoutes'));
 app.use('/api/admins', require('./routes/adminRoutes'));
+app.use('/api/payroll', require('./routes/payrollRoutes'));
 
 // Automatically remove last month's verified attendance records on the 10th of each month
 cron.schedule('0 0 10 * *', async () => {


### PR DESCRIPTION
## Summary
- add endpoints to save payroll records and retrieve history
- implement payroll history page in the frontend
- allow confirming payroll records
- expose payroll history route and link in navbar

## Testing
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d1467b6cc8323b12f0724f41e92c1