### PR TITLE
Improve bill upload workflow

### DIFF
--- a/server/src/routes/deductionRoutes.js
+++ b/server/src/routes/deductionRoutes.js
@@ -27,10 +27,7 @@ router.get('/electric/history/:address', authMiddleware, deductionController.get
 router.put(
   '/electric/:address',
   authMiddleware,
-  upload.fields([
-    { name: 'lastBill', maxCount: 1 },
-    { name: 'currentBill', maxCount: 1 },
-  ]),
+  upload.fields([{ name: 'currentBill', maxCount: 1 }]),
   deductionController.updateElectricCharge
 );
 router.delete('/electric/:address', authMiddleware, deductionController.deleteElectricAddress);


### PR DESCRIPTION
## Summary
- update deduction routes to accept only current bill upload for electricity
- automatically set the previous bill from last month on the server
- preview water and electric bill images before saving
- clear bill images after saving

## Testing
- `npm run lint` in `client`
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d2aa1dd3c8323a05ffe40849d4823