### PR TITLE
Improve advance info in payroll history

### DIFF
--- a/client/src/pages/PayrollHistoryPage.jsx
+++ b/client/src/pages/PayrollHistoryPage.jsx
@@ -95,7 +95,22 @@ function PayrollHistoryPage() {
                 </td>
               );
             })}
-            <td className="px-2 py-1 text-right">{Number(p.advance_total || 0).toFixed(2)}</td>
+            <td className="px-2 py-1">
+              {p.advance_details && p.advance_details.length > 0 ? (
+                <div className="space-y-1">
+                  {p.advance_details.map((a, idx) => (
+                    <div key={idx} className="whitespace-nowrap">
+                      {`${a.name} เหลือ ${a.remaining.toFixed(2)} ${a.remark || ''}`}
+                    </div>
+                  ))}
+                  <div className="text-right font-semibold">
+                    {Number(p.advance_total).toFixed(2)}
+                  </div>
+                </div>
+              ) : (
+                Number(p.advance_total || 0).toFixed(2)
+              )}
+            </td>
             <td className="px-2 py-1 text-right">
               {p.savings_deposit > 0 && `ฝาก ${Number(p.savings_deposit).toFixed(2)}`}
               {p.savings_withdraw > 0 && `ถอน ${Number(p.savings_withdraw).toFixed(2)}`}

--- a/server/src/controllers/payrollController.js
+++ b/server/src/controllers/payrollController.js
@@ -576,13 +576,21 @@ exports.getMonthlyHistory = async (req, res) => {
       });
 
       const { rows: adv } = await pool.query(
-        `SELECT COALESCE(SUM(-t.amount),0) AS total
+        `SELECT a.name, a.total_amount, -t.amount AS amount, t.remark
            FROM AdvanceTransactions t
-           JOIN AdvanceLoans a ON t.advance_id=a.id
-          WHERE a.employee_id=$1 AND t.transaction_date=$2 AND t.amount<0`,
+           JOIN AdvanceLoans a ON t.advance_id = a.id
+          WHERE a.employee_id = $1
+            AND t.transaction_date = $2
+            AND t.amount < 0`,
         [r.employee_id, r.pay_month]
       );
-      r.advance_total = parseFloat(adv[0].total) || 0;
+      r.advance_details = adv.map((a) => ({
+        name: a.name,
+        remaining: parseFloat(a.total_amount),
+        amount: parseFloat(a.amount),
+        remark: a.remark || '',
+      }));
+      r.advance_total = r.advance_details.reduce((sum, a) => sum + a.amount, 0);
 
       const { rows: sav } = await pool.query(
         'SELECT amount, is_deposit FROM SavingsTransactions WHERE employee_id=$1 AND transaction_date=$2',
@@ -637,13 +645,21 @@ exports.getSemiMonthlyHistory = async (req, res) => {
       });
 
       const { rows: adv } = await pool.query(
-        `SELECT COALESCE(SUM(-t.amount),0) AS total
+        `SELECT a.name, a.total_amount, -t.amount AS amount, t.remark
            FROM AdvanceTransactions t
-           JOIN AdvanceLoans a ON t.advance_id=a.id
-          WHERE a.employee_id=$1 AND t.transaction_date=$2 AND t.amount<0`,
+           JOIN AdvanceLoans a ON t.advance_id = a.id
+          WHERE a.employee_id = $1
+            AND t.transaction_date = $2
+            AND t.amount < 0`,
         [r.employee_id, r.pay_month]
       );
-      r.advance_total = parseFloat(adv[0].total) || 0;
+      r.advance_details = adv.map((a) => ({
+        name: a.name,
+        remaining: parseFloat(a.total_amount),
+        amount: parseFloat(a.amount),
+        remark: a.remark || '',
+      }));
+      r.advance_total = r.advance_details.reduce((sum, a) => sum + a.amount, 0);
 
       const { rows: sav } = await pool.query(
         'SELECT amount, is_deposit FROM SavingsTransactions WHERE employee_id=$1 AND transaction_date=$2',


### PR DESCRIPTION
## Summary
- show detailed advance info in payroll history table
- return advance details from payroll history APIs

## Testing
- `npm run lint` in `client`
- `npm run lint` *(fails: Missing script)* in `server`


------
https://chatgpt.com/codex/tasks/task_e_684d3a280bd483238371158cbc46b239