### PR TITLE
Restrict employee access by supervisor

### DIFF
--- a/server/src/utils/permissions.js
+++ b/server/src/utils/permissions.js
@@ -1,0 +1,17 @@
+const pool = require('../config/db');
+
+async function isSuperuser(adminId) {
+    const { rows } = await pool.query('SELECT is_superuser FROM Admins WHERE id=$1', [adminId]);
+    return rows.length > 0 && rows[0].is_superuser === true;
+}
+
+async function canAccessEmployee(adminId, employeeId) {
+    if (await isSuperuser(adminId)) return true;
+    const { rows } = await pool.query(
+        'SELECT 1 FROM Employees WHERE id=$1 AND supervisor_admin_id=$2',
+        [employeeId, adminId]
+    );
+    return rows.length > 0;
+}
+
+module.exports = { isSuperuser, canAccessEmployee };


### PR DESCRIPTION
## Summary
- add permission utilities
- filter employee queries by supervisor
- only superusers can assign/change supervisors
- check supervisor ownership on update/delete

## Testing
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d47ad1a408323a37e2d23633650a2