### PR TITLE
Disable payroll edits after confirmation

### DIFF
--- a/client/src/pages/PayrollPage.jsx
+++ b/client/src/pages/PayrollPage.jsx
@@ -83,6 +83,7 @@ function PayrollPage() {
 
 
   const handleConfirm = async (id) => {
+    if (!window.confirm('เมื่อยืนยันแล้วจะไม่สามารถแก้ไขได้')) return;
     const adv = advanceInputs[id] || {};
     const advArr = Object.keys(adv).map((key) => ({
       id: parseInt(key, 10),
@@ -105,6 +106,7 @@ function PayrollPage() {
         await axios.post('/api/payroll/semi-monthly/record', { ...payload, period: p });
       }
       alert('บันทึกสำเร็จ');
+      setPayroll((prev) => prev.filter((p) => p.employee_id !== id));
     } catch (err) {
       console.error(err);
       alert('บันทึกไม่สำเร็จ');


### PR DESCRIPTION
## Summary
- warn admins that payroll records cannot be edited once confirmed
- hide already confirmed payroll records from monthly and semi-monthly views
- prevent duplicate payroll records
- filter half-month records by month and period

## Testing
- `npm --prefix client run lint`
- `npm --prefix server run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d4d4452888323a6f6dd668653662a