### PR TITLE
Improve admin navbar toggling

### DIFF
--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -11,24 +11,26 @@ const AdminNavbar = ({ adminUser, onLogout }) => {
           ระบบจัดการพนักงาน
         </Link>
 
-        <button
-          className="sm:hidden focus:outline-none"
-          onClick={() => setMenuOpen(!menuOpen)}
-          aria-label="Toggle navigation"
-        >
-          {menuOpen ? (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          )}
-        </button>
-
-        <div className={`${menuOpen ? 'flex' : 'hidden'} sm:flex flex-col sm:flex-row flex-wrap items-center space-y-2 sm:space-y-0 sm:space-x-4 w-full sm:w-auto mt-2 sm:mt-0`}>
+        <div className="flex items-center space-x-4">
           {adminUser && <span className="text-sm">ผู้ใช้: {adminUser.name}</span>}
+          <button
+            className="focus:outline-none"
+            onClick={() => setMenuOpen(!menuOpen)}
+            aria-label="Toggle navigation"
+          >
+            {menuOpen ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            )}
+          </button>
+        </div>
+
+        <div className={`${menuOpen ? 'flex' : 'hidden'} flex-col sm:flex-row flex-wrap items-center space-y-2 sm:space-y-0 sm:space-x-4 w-full sm:w-auto mt-2 sm:mt-0`}>
           <Link to="/" className="hover:text-green-100">หน้าลงเวลา</Link>
           <Link to="/admin/employees" className="hover:text-green-100">รายชื่อพนักงาน</Link>
           <Link to="/admin/attendance-review" className="hover:text-green-100">ตรวจสอบการลงชื่อ</Link>


### PR DESCRIPTION
## Summary
- keep admin username visible
- toggle all navigation links with a hamburger icon
- ensure navbar text stays white

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d6b511800832386027a5ce3c4ac1e