### PR TITLE
Enable editing payroll history

### DIFF
--- a/server/src/routes/payrollRoutes.js
+++ b/server/src/routes/payrollRoutes.js
@@ -9,5 +9,7 @@ router.post('/monthly/record', authMiddleware, payrollController.recordMonthlyPa
 router.post('/semi-monthly/record', authMiddleware, payrollController.recordSemiMonthlyPayroll);
 router.get('/monthly/history', authMiddleware, payrollController.getMonthlyHistory);
 router.get('/semi-monthly/history', authMiddleware, payrollController.getSemiMonthlyHistory);
+router.put('/monthly/history/:id', authMiddleware, payrollController.updateMonthlyRecord);
+router.put('/semi-monthly/history/:id', authMiddleware, payrollController.updateSemiMonthlyRecord);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow real-time editing of payroll history rows
- expose API endpoints for updating monthly and semi-monthly payroll records
- include daily wage in monthly history and compute values server side
- allow editing advance and savings amounts without duplicating balances

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e2fe85b5c832389bc2653427d4c07