### PR TITLE
Repeat table headers on each payroll entry

### DIFF
--- a/client/src/pages/PayrollHistoryPage.jsx
+++ b/client/src/pages/PayrollHistoryPage.jsx
@@ -97,37 +97,41 @@ function PayrollHistoryPage() {
     };
   };
 
+  const renderHeader = (showPeriod = false) => (
+    <>
+      <tr className="bg-gray-100">
+        <th rowSpan="2" className="px-2 py-2">รหัส</th>
+        <th rowSpan="2" className="px-2 py-2 text-left">ชื่อพนักงาน</th>
+        {showPeriod && <th rowSpan="2" className="px-2 py-2">รอบ</th>}
+        <th rowSpan="2" className="px-2 py-2">รายการ</th>
+        <th colSpan="9" className="px-2 py-2 text-center">รายได้</th>
+        <th colSpan={5 + deductionTypes.length} className="px-2 py-2 text-center">รายหัก</th>
+        <th rowSpan="2" className="px-2 py-2">รับสุทธิ</th>
+      </tr>
+      <tr className="bg-gray-100">
+        <th className="px-2 py-2">วันทำงาน</th>
+        <th className="px-2 py-2">ชั่วโมง</th>
+        <th className="px-2 py-2">เบี้ยขยัน</th>
+        <th className="px-2 py-2">ค่าแรงรวม</th>
+        <th className="px-2 py-2">OT(ชม.)</th>
+        <th className="px-2 py-2">ค่า OT</th>
+        <th className="px-2 py-2">อาทิตย์(วัน)</th>
+        <th className="px-2 py-2">ค่าอาทิตย์</th>
+        <th className="px-2 py-2">รวมรายได้</th>
+        <th className="px-2 py-2">ค่าน้ำ</th>
+        <th className="px-2 py-2">ค่าไฟ</th>
+        {deductionTypes.map((d) => (
+          <th key={d.id} className="px-2 py-2">{`${d.name} (${parseFloat(d.rate)}%)`}</th>
+        ))}
+        <th className="px-2 py-2">เงินเบิก</th>
+        <th className="px-2 py-2">เงินเก็บสะสม</th>
+        <th className="px-2 py-2">รวมยอดหัก</th>
+      </tr>
+    </>
+  );
+
   const renderTable = () => (
     <table className="min-w-full bg-white shadow rounded text-sm">
-      <thead className="bg-gray-100">
-        <tr>
-          <th rowSpan="2" className="px-2 py-2">รหัส</th>
-          <th rowSpan="2" className="px-2 py-2 text-left">ชื่อพนักงาน</th>
-          {cycle === 'ครึ่งเดือน' && <th rowSpan="2" className="px-2 py-2">รอบ</th>}
-          <th colSpan="9" className="px-2 py-2 text-center">รายได้</th>
-          <th colSpan={5 + deductionTypes.length} className="px-2 py-2 text-center">รายหัก</th>
-          <th rowSpan="2" className="px-2 py-2">รับสุทธิ</th>
-        </tr>
-        <tr>
-          <th className="px-2 py-2">วันทำงาน</th>
-          <th className="px-2 py-2">ชั่วโมง</th>
-          <th className="px-2 py-2">เบี้ยขยัน</th>
-          <th className="px-2 py-2">ค่าแรงรวม</th>
-          <th className="px-2 py-2">OT(ชม.)</th>
-          <th className="px-2 py-2">ค่า OT</th>
-          <th className="px-2 py-2">อาทิตย์(วัน)</th>
-          <th className="px-2 py-2">ค่าอาทิตย์</th>
-          <th className="px-2 py-2">รวมรายได้</th>
-          <th className="px-2 py-2">ค่าน้ำ</th>
-          <th className="px-2 py-2">ค่าไฟ</th>
-          {deductionTypes.map((d) => (
-            <th key={d.id} className="px-2 py-2">{`${d.name} (${parseFloat(d.rate)}%)`}</th>
-          ))}
-          <th className="px-2 py-2">เงินเบิก</th>
-          <th className="px-2 py-2">เงินเก็บสะสม</th>
-          <th className="px-2 py-2">รวมยอดหัก</th>
-        </tr>
-      </thead>
       <tbody>
         {records.map((p) => {
           const key = `${p.employee_id}-${p.period || 'm'}`;
@@ -135,6 +139,7 @@ function PayrollHistoryPage() {
           const vals = isEdit ? computeValues(p, editInputs) : {};
           return (
             <React.Fragment key={key}>
+              {renderHeader(cycle === 'ครึ่งเดือน')}
               <tr className="border-t">
                 <td rowSpan="3" className="px-2 py-1 text-center">{p.employee_id}</td>
                 <td rowSpan="3" className="px-2 py-1">
@@ -148,6 +153,7 @@ function PayrollHistoryPage() {
                     {p.period === 'first' ? '1-15' : '16-สิ้นเดือน'}
                   </td>
                 )}
+                <td className="px-2 py-1 font-semibold text-center bg-gray-50">รายได้</td>
                 <td className="px-2 py-1 text-center">
                   {isEdit ? (
                     <input
@@ -227,6 +233,7 @@ function PayrollHistoryPage() {
                 <td className="px-2 py-1" />
               </tr>
               <tr>
+                <td className="px-2 py-1 font-semibold text-center bg-gray-50">รายการหัก</td>
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />
@@ -325,6 +332,7 @@ function PayrollHistoryPage() {
                 <td className="px-2 py-1" />
               </tr>
               <tr>
+                <td className="px-2 py-1 font-semibold text-center bg-gray-50">รับสุทธิ</td>
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />

--- a/client/src/pages/PayrollPage.jsx
+++ b/client/src/pages/PayrollPage.jsx
@@ -113,54 +113,60 @@ function PayrollPage() {
     }
   };
 
+  const renderHeader = (showDeduction = true) => (
+    <>
+      <tr className="bg-gray-100">
+        <th rowSpan="2" className="px-2 py-2">รหัส</th>
+        <th rowSpan="2" className="px-2 py-2 text-left">ชื่อพนักงาน</th>
+        <th rowSpan="2" className="px-2 py-2">รายการ</th>
+        <th colSpan="9" className="px-2 py-2 text-center">รายได้</th>
+        {showDeduction && (
+          <th
+            colSpan={5 + deductionTypes.length}
+            className="px-2 py-2 text-center"
+          >
+            รายหัก
+          </th>
+        )}
+        {!showDeduction && <th rowSpan="2" className="px-2 py-2">รายหัก</th>}
+        <th rowSpan="2" className="px-2 py-2">รับสุทธิ</th>
+        <th rowSpan="2" className="px-2 py-2" />
+      </tr>
+      <tr className="bg-gray-100">
+        <th className="px-2 py-2">วันทำงาน</th>
+        <th className="px-2 py-2">ชั่วโมง</th>
+        <th className="px-2 py-2">เบี้ยขยัน</th>
+        <th className="px-2 py-2">ค่าแรงรวม</th>
+        <th className="px-2 py-2">OT(ชม.)</th>
+        <th className="px-2 py-2">ค่า OT</th>
+        <th className="px-2 py-2">อาทิตย์(วัน)</th>
+        <th className="px-2 py-2">ค่าอาทิตย์</th>
+        <th className="px-2 py-2">รวมรายได้</th>
+        {showDeduction && <th className="px-2 py-2">ค่าน้ำ</th>}
+        {showDeduction && <th className="px-2 py-2">ค่าไฟ</th>}
+        {showDeduction &&
+          deductionTypes.map((d) => (
+            <th key={d.id} className="px-2 py-2">
+              {`${d.name} (${parseFloat(d.rate)}%)`}
+            </th>
+          ))}
+        {showDeduction && <th className="px-2 py-2">เงินเบิก</th>}
+        {showDeduction && <th className="px-2 py-2">เงินเก็บสะสม</th>}
+        {showDeduction && <th className="px-2 py-2">รวมยอดหัก</th>}
+      </tr>
+    </>
+  );
+
   const renderPayrollTable = (data, showDeduction = true) => (
     <table className="min-w-full bg-white shadow rounded text-sm">
-      <thead className="bg-gray-100">
-        <tr>
-          <th rowSpan="2" className="px-2 py-2">รหัส</th>
-          <th rowSpan="2" className="px-2 py-2 text-left">ชื่อพนักงาน</th>
-          <th colSpan="9" className="px-2 py-2 text-center">รายได้</th>
-          {showDeduction && (
-            <th
-              colSpan={5 + deductionTypes.length}
-              className="px-2 py-2 text-center"
-            >
-              รายหัก
-            </th>
-          )}
-          {!showDeduction && <th rowSpan="2" className="px-2 py-2">รายหัก</th>}
-          <th rowSpan="2" className="px-2 py-2">รับสุทธิ</th>
-          <th rowSpan="2" className="px-2 py-2" />
-        </tr>
-        <tr>
-          <th className="px-2 py-2">วันทำงาน</th>
-          <th className="px-2 py-2">ชั่วโมง</th>
-          <th className="px-2 py-2">เบี้ยขยัน</th>
-          <th className="px-2 py-2">ค่าแรงรวม</th>
-          <th className="px-2 py-2">OT(ชม.)</th>
-          <th className="px-2 py-2">ค่า OT</th>
-          <th className="px-2 py-2">อาทิตย์(วัน)</th>
-          <th className="px-2 py-2">ค่าอาทิตย์</th>
-          <th className="px-2 py-2">รวมรายได้</th>
-          {showDeduction && <th className="px-2 py-2">ค่าน้ำ</th>}
-          {showDeduction && <th className="px-2 py-2">ค่าไฟ</th>}
-          {showDeduction &&
-            deductionTypes.map((d) => (
-              <th key={d.id} className="px-2 py-2">
-                {`${d.name} (${parseFloat(d.rate)}%)`}
-              </th>
-            ))}
-          {showDeduction && <th className="px-2 py-2">เงินเบิก</th>}
-          {showDeduction && <th className="px-2 py-2">เงินเก็บสะสม</th>}
-          {showDeduction && <th className="px-2 py-2">รวมยอดหัก</th>}
-        </tr>
-      </thead>
       <tbody>
         {data.map((p) => (
           <React.Fragment key={p.employee_id}>
+            {renderHeader(showDeduction)}
             <tr className="border-t">
               <td rowSpan="3" className="px-2 py-1 text-center">{p.employee_id}</td>
               <td rowSpan="3" className="px-2 py-1">{p.name}</td>
+              <td className="px-2 py-1 font-semibold text-center bg-gray-50">รายได้</td>
               <td className="px-2 py-1 text-center">{p.days_worked}</td>
               <td className="px-2 py-1 text-center">{p.hours_worked}</td>
               <td className="px-2 py-1 text-center">{p.bonus_count}</td>
@@ -187,6 +193,7 @@ function PayrollPage() {
               <td className="px-2 py-1" />
             </tr>
             <tr>
+              <td className="px-2 py-1 font-semibold text-center bg-gray-50">รายการหัก</td>
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />
@@ -309,6 +316,7 @@ function PayrollPage() {
               <td className="px-2 py-1" />
             </tr>
             <tr>
+              <td className="px-2 py-1 font-semibold text-center bg-gray-50">รับสุทธิ</td>
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />


### PR DESCRIPTION
## Summary
- display payroll column titles for every employee entry
- show the same repeated headers on payroll history records
- add row labels so each row is clearly marked as income, deductions, or net pay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68529f5057748323affcf197656cf93d