### PR TITLE
Update payroll table layout

### DIFF
--- a/client/src/pages/PayrollHistoryPage.jsx
+++ b/client/src/pages/PayrollHistoryPage.jsx
@@ -97,36 +97,52 @@ function PayrollHistoryPage() {
     };
   };
 
-  const renderHeader = (showPeriod = false) => (
-    <>
-      <tr className="bg-gray-100">
-        <th rowSpan="2" className="px-2 py-2">รหัส</th>
-        <th rowSpan="2" className="px-2 py-2 text-left">ชื่อพนักงาน</th>
-        {showPeriod && <th rowSpan="2" className="px-2 py-2">รอบ</th>}
-        <th colSpan="9" className="px-2 py-2 text-center">รายได้</th>
-        <th colSpan={5 + deductionTypes.length} className="px-2 py-2 text-center">รายหัก</th>
-        <th rowSpan="2" className="px-2 py-2">รับสุทธิ</th>
-      </tr>
-      <tr className="bg-gray-100">
-        <th className="px-2 py-2">วันทำงาน</th>
-        <th className="px-2 py-2">ชั่วโมง</th>
-        <th className="px-2 py-2">เบี้ยขยัน</th>
-        <th className="px-2 py-2">ค่าแรงรวม</th>
-        <th className="px-2 py-2">OT(ชม.)</th>
-        <th className="px-2 py-2">ค่า OT</th>
-        <th className="px-2 py-2">อาทิตย์(วัน)</th>
-        <th className="px-2 py-2">ค่าอาทิตย์</th>
-        <th className="px-2 py-2">รวมรายได้</th>
-        <th className="px-2 py-2">ค่าน้ำ</th>
-        <th className="px-2 py-2">ค่าไฟ</th>
-        {deductionTypes.map((d) => (
-          <th key={d.id} className="px-2 py-2">{`${d.name} (${parseFloat(d.rate)}%)`}</th>
-        ))}
-        <th className="px-2 py-2">เงินเบิก</th>
-        <th className="px-2 py-2">เงินเก็บสะสม</th>
-        <th className="px-2 py-2">รวมยอดหัก</th>
-      </tr>
-    </>
+  const renderIncomeHeader = (showPeriod) => (
+    <tr className="bg-gray-100">
+      <th className="px-2 py-2">รหัส</th>
+      <th className="px-2 py-2 text-left">ชื่อพนักงาน</th>
+      {showPeriod && <th className="px-2 py-2">รอบ</th>}
+      <th className="px-2 py-2">วันทำงาน</th>
+      <th className="px-2 py-2">ชั่วโมง</th>
+      <th className="px-2 py-2">เบี้ยขยัน</th>
+      <th className="px-2 py-2">ค่าแรงรวม</th>
+      <th className="px-2 py-2">OT(ชม.)</th>
+      <th className="px-2 py-2">ค่า OT</th>
+      <th className="px-2 py-2">อาทิตย์(วัน)</th>
+      <th className="px-2 py-2">ค่าอาทิตย์</th>
+      <th className="px-2 py-2">รวมรายได้</th>
+      <th colSpan={5 + deductionTypes.length + 1} />
+    </tr>
+  );
+
+  const renderDeductionHeader = (showPeriod) => (
+    <tr className="bg-gray-100">
+      <th />
+      <th />
+      {showPeriod && <th />}
+      <th colSpan="9" className="text-center">รายหัก</th>
+      <th className="px-2 py-2">ค่าน้ำ</th>
+      <th className="px-2 py-2">ค่าไฟ</th>
+      {deductionTypes.map((d) => (
+        <th key={d.id} className="px-2 py-2">
+          {`${d.name} (${parseFloat(d.rate)}%)`}
+        </th>
+      ))}
+      <th className="px-2 py-2">เงินเบิก</th>
+      <th className="px-2 py-2">เงินเก็บสะสม</th>
+      <th className="px-2 py-2">รวมยอดหัก</th>
+      <th />
+    </tr>
+  );
+
+  const renderNetHeader = (showPeriod) => (
+    <tr className="bg-gray-100">
+      <th />
+      <th />
+      {showPeriod && <th />}
+      <th colSpan={9 + 5 + deductionTypes.length} />
+      <th className="px-2 py-2">รับสุทธิ</th>
+    </tr>
   );
 
   const renderTable = () => (
@@ -138,17 +154,17 @@ function PayrollHistoryPage() {
           const vals = isEdit ? computeValues(p, editInputs) : {};
           return (
             <React.Fragment key={key}>
-              {renderHeader(cycle === 'ครึ่งเดือน')}
+              {renderIncomeHeader(cycle === 'ครึ่งเดือน')}
               <tr className="border-t">
-                <td rowSpan="3" className="px-2 py-1 text-center">{p.employee_id}</td>
-                <td rowSpan="3" className="px-2 py-1">
+                <td rowSpan="5" className="px-2 py-1 text-center">{p.employee_id}</td>
+                <td rowSpan="5" className="px-2 py-1">
                   <div>{`${p.first_name} ${p.last_name}`}</div>
                   <div className="text-xs text-gray-500 whitespace-nowrap">
                     {p.bank_account_name || '-'} {p.bank_account_number || ''} {p.bank_name || ''}
                   </div>
                 </td>
                 {cycle === 'ครึ่งเดือน' && (
-                  <td rowSpan="3" className="px-2 py-1 text-center">
+                  <td rowSpan="5" className="px-2 py-1 text-center">
                     {p.period === 'first' ? '1-15' : '16-สิ้นเดือน'}
                   </td>
                 )}
@@ -228,9 +244,10 @@ function PayrollHistoryPage() {
                     <td className="px-2 py-1" />
                   </>
                 )}
-                <td className="px-2 py-1" />
-              </tr>
-              <tr>
+                  <td className="px-2 py-1" />
+                </tr>
+                {renderDeductionHeader(cycle === 'ครึ่งเดือน')}
+                <tr>
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />
@@ -328,6 +345,7 @@ function PayrollHistoryPage() {
                 <td className="px-2 py-1 text-right">{isEdit ? vals.deductionsTotal.toFixed(2) : Number(p.deductions_total).toFixed(2)}</td>
                 <td className="px-2 py-1" />
               </tr>
+              {renderNetHeader(cycle === 'ครึ่งเดือน')}
               <tr>
                 <td className="px-2 py-1" />
                 <td className="px-2 py-1" />

--- a/client/src/pages/PayrollPage.jsx
+++ b/client/src/pages/PayrollPage.jsx
@@ -113,47 +113,75 @@ function PayrollPage() {
     }
   };
 
-  const renderHeader = (showDeduction = true) => (
-    <>
-      <tr className="bg-gray-100">
-        <th rowSpan="2" className="px-2 py-2">รหัส</th>
-        <th rowSpan="2" className="px-2 py-2 text-left">ชื่อพนักงาน</th>
-        <th colSpan="9" className="px-2 py-2 text-center">รายได้</th>
-        {showDeduction && (
-          <th
-            colSpan={5 + deductionTypes.length}
-            className="px-2 py-2 text-center"
-          >
-            รายหัก
-          </th>
-        )}
-        {!showDeduction && <th rowSpan="2" className="px-2 py-2">รายหัก</th>}
-        <th rowSpan="2" className="px-2 py-2">รับสุทธิ</th>
-        <th rowSpan="2" className="px-2 py-2" />
-      </tr>
-      <tr className="bg-gray-100">
-        <th className="px-2 py-2">วันทำงาน</th>
-        <th className="px-2 py-2">ชั่วโมง</th>
-        <th className="px-2 py-2">เบี้ยขยัน</th>
-        <th className="px-2 py-2">ค่าแรงรวม</th>
-        <th className="px-2 py-2">OT(ชม.)</th>
-        <th className="px-2 py-2">ค่า OT</th>
-        <th className="px-2 py-2">อาทิตย์(วัน)</th>
-        <th className="px-2 py-2">ค่าอาทิตย์</th>
-        <th className="px-2 py-2">รวมรายได้</th>
-        {showDeduction && <th className="px-2 py-2">ค่าน้ำ</th>}
-        {showDeduction && <th className="px-2 py-2">ค่าไฟ</th>}
-        {showDeduction &&
-          deductionTypes.map((d) => (
+  const renderIncomeHeader = (showDeduction) => (
+    <tr className="bg-gray-100">
+      <th className="px-2 py-2">รหัส</th>
+      <th className="px-2 py-2 text-left">ชื่อพนักงาน</th>
+      <th className="px-2 py-2">วันทำงาน</th>
+      <th className="px-2 py-2">ชั่วโมง</th>
+      <th className="px-2 py-2">เบี้ยขยัน</th>
+      <th className="px-2 py-2">ค่าแรงรวม</th>
+      <th className="px-2 py-2">OT(ชม.)</th>
+      <th className="px-2 py-2">ค่า OT</th>
+      <th className="px-2 py-2">อาทิตย์(วัน)</th>
+      <th className="px-2 py-2">ค่าอาทิตย์</th>
+      <th className="px-2 py-2">รวมรายได้</th>
+      {showDeduction && (
+        <>
+          <th colSpan={5 + deductionTypes.length} />
+          <th />
+          <th />
+        </>
+      )}
+      {!showDeduction && (
+        <>
+          <th />
+          <th />
+          <th />
+        </>
+      )}
+    </tr>
+  );
+
+  const renderDeductionHeader = (showDeduction) => (
+    <tr className="bg-gray-100">
+      <th />
+      <th />
+      <th colSpan="9" className="text-center">รายหัก</th>
+      {showDeduction && (
+        <>
+          <th className="px-2 py-2">ค่าน้ำ</th>
+          <th className="px-2 py-2">ค่าไฟ</th>
+          {deductionTypes.map((d) => (
             <th key={d.id} className="px-2 py-2">
               {`${d.name} (${parseFloat(d.rate)}%)`}
             </th>
           ))}
-        {showDeduction && <th className="px-2 py-2">เงินเบิก</th>}
-        {showDeduction && <th className="px-2 py-2">เงินเก็บสะสม</th>}
-        {showDeduction && <th className="px-2 py-2">รวมยอดหัก</th>}
-      </tr>
-    </>
+          <th className="px-2 py-2">เงินเบิก</th>
+          <th className="px-2 py-2">เงินเก็บสะสม</th>
+          <th className="px-2 py-2">รวมยอดหัก</th>
+          <th />
+          <th />
+        </>
+      )}
+      {!showDeduction && (
+        <>
+          <th className="px-2 py-2">รายหัก</th>
+          <th />
+          <th />
+        </>
+      )}
+    </tr>
+  );
+
+  const renderNetHeader = (showDeduction) => (
+    <tr className="bg-gray-100">
+      <th />
+      <th />
+      <th colSpan={9 + (showDeduction ? 5 + deductionTypes.length : 1)} />
+      <th className="px-2 py-2">รับสุทธิ</th>
+      <th className="px-2 py-2" />
+    </tr>
   );
 
   const renderPayrollTable = (data, showDeduction = true) => (
@@ -161,10 +189,10 @@ function PayrollPage() {
       <tbody>
         {data.map((p) => (
           <React.Fragment key={p.employee_id}>
-            {renderHeader(showDeduction)}
+            {renderIncomeHeader(showDeduction)}
             <tr className="border-t">
-              <td rowSpan="3" className="px-2 py-1 text-center">{p.employee_id}</td>
-              <td rowSpan="3" className="px-2 py-1">{p.name}</td>
+              <td rowSpan="5" className="px-2 py-1 text-center">{p.employee_id}</td>
+              <td rowSpan="5" className="px-2 py-1">{p.name}</td>
               <td className="px-2 py-1 text-center">{p.days_worked}</td>
               <td className="px-2 py-1 text-center">{p.hours_worked}</td>
               <td className="px-2 py-1 text-center">{p.bonus_count}</td>
@@ -190,6 +218,7 @@ function PayrollPage() {
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />
             </tr>
+            {renderDeductionHeader(showDeduction)}
             <tr>
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />
@@ -312,6 +341,7 @@ function PayrollPage() {
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />
             </tr>
+            {renderNetHeader(showDeduction)}
             <tr>
               <td className="px-2 py-1" />
               <td className="px-2 py-1" />


### PR DESCRIPTION
## Summary
- reorganize payroll table rows into income, deduction, and net income sections
- mirror the same layout in payroll history

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852ae30b3948323addb2e065759785f