### PR TITLE
Group payroll data by nationality

### DIFF
--- a/client/src/pages/PayrollPage.jsx
+++ b/client/src/pages/PayrollPage.jsx
@@ -176,8 +176,15 @@ function PayrollPage() {
         `}
       </style>
       <tbody className="payroll-bordered">
-        {data.map((p) => (
+        {data.map((p, idx) => (
           <React.Fragment key={p.employee_id}>
+            {(idx === 0 || p.nationality !== data[idx - 1].nationality) && (
+              <tr className="bg-blue-100">
+                <td colSpan={100} className="px-2 py-1 font-semibold text-left">
+                  {p.nationality === 'ไทย' ? 'คนไทย' : 'ต่างชาติ'}
+                </td>
+              </tr>
+            )}
             {renderIncomeHeader()}
             <tr className={`border-t ${fixedRowClass}`}>
               <td rowSpan="5" className="px-2 py-1">


### PR DESCRIPTION
## Summary
- group rows by nationality in payroll pages
- show Thai employees before foreign employees in history page

## Testing
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852fa2a3b80832383a400c569387823