### PR TITLE
Enforce dd/mm/yyyy date inputs

### DIFF
--- a/client/src/pages/AttendancePage.jsx
+++ b/client/src/pages/AttendancePage.jsx
@@ -151,6 +151,7 @@ function AttendancePage() {
               <input
                 type="date"
                 id="attendanceDate"
+                lang="en-GB"
                 value={attendanceDate}
                 onChange={(e) => setAttendanceDate(e.target.value)}
                 className="text-gray-900 mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"

--- a/client/src/pages/AttendanceReviewPage.jsx
+++ b/client/src/pages/AttendanceReviewPage.jsx
@@ -231,7 +231,7 @@ function AttendanceReviewPage() {
                   </div>
                   <div>
                     <label className="block text-xs font-medium text-gray-700 mb-1">วันที่</label>
-                    <input type="date" value={editData.attendanceDate} onChange={(e)=>handleEditChange('attendanceDate', e.target.value)} className="border p-2 w-full" required />
+                    <input type="date" lang="en-GB" value={editData.attendanceDate} onChange={(e)=>handleEditChange('attendanceDate', e.target.value)} className="border p-2 w-full" required />
                   </div>
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-8">

--- a/client/src/pages/DeductionManagementPage.jsx
+++ b/client/src/pages/DeductionManagementPage.jsx
@@ -405,7 +405,7 @@ function DeductionManagementPage() {
                 <input type="number" value={a.addAmount} onChange={(e)=>handleAdvanceChange(idx,'addAmount',e.target.value)} className="border p-1 w-24" />
               </td>
               <td className="px-4 py-2">
-                <input type="date" value={a.addDate} onChange={(e)=>handleAdvanceChange(idx,'addDate',e.target.value)} className="border p-1" />
+                <input type="date" lang="en-GB" value={a.addDate} onChange={(e)=>handleAdvanceChange(idx,'addDate',e.target.value)} className="border p-1" />
               </td>
               <td className="px-4 py-2">
                 <input type="text" value={a.remark} onChange={(e)=>handleAdvanceChange(idx,'remark',e.target.value)} className="border p-1" />

--- a/client/src/pages/EmployeeListPage.jsx
+++ b/client/src/pages/EmployeeListPage.jsx
@@ -324,7 +324,7 @@ function EmployeeListPage() {
                   </div>
                    <div>
                     <label htmlFor="start_date" className="block text-sm font-medium text-gray-700">วันที่เริ่มงาน</label>
-                    <input type="date" name="start_date" id="start_date" value={formData.start_date} onChange={handleFormChange} className="text-gray-900 mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-sky-500 focus:ring-sky-500 sm:text-sm p-2" />
+                    <input type="date" lang="en-GB" name="start_date" id="start_date" value={formData.start_date} onChange={handleFormChange} className="text-gray-900 mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-sky-500 focus:ring-sky-500 sm:text-sm p-2" />
                   </div>
                   <div>
                     <label htmlFor="water_address" className="block text-sm font-medium text-gray-700">ที่อยู่น้ำ</label>


### PR DESCRIPTION
## Summary
- set `lang="en-GB"` on all date inputs
- ensure attendance pages always show day/month/year

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853add9c63c83238eeb6c08afe54520