### PR TITLE
Update locale to enforce dd/mm/yyyy

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-GB">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/client/src/pages/AttendancePage.jsx
+++ b/client/src/pages/AttendancePage.jsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { isoToDDMMYYYY, ddmmyyyyToIso } from '../utils/date';
 
 function AttendancePage() {
   const [siteName, setSiteName] = useState('');
-  const [attendanceDate, setAttendanceDate] = useState(new Date().toISOString().slice(0, 10));
+  const initialIso = new Date().toISOString().slice(0, 10);
+  const [attendanceDate, setAttendanceDate] = useState(initialIso);
+  const [attendanceDateDisplay, setAttendanceDateDisplay] = useState(isoToDDMMYYYY(initialIso));
   const [siteSupervisor, setSiteSupervisor] = useState('');
   const [supervisorCheckIn, setSupervisorCheckIn] = useState('');
   const [supervisorCheckOut, setSupervisorCheckOut] = useState('');
@@ -107,7 +110,9 @@ function AttendancePage() {
 
   const handleClearForm = () => {
     setSiteName('');
-    setAttendanceDate(new Date().toISOString().slice(0,10));
+    const iso = new Date().toISOString().slice(0,10);
+    setAttendanceDate(iso);
+    setAttendanceDateDisplay(isoToDDMMYYYY(iso));
     setSiteSupervisor('');
     setSupervisorCheckIn('');
     setSupervisorCheckOut('');
@@ -149,11 +154,15 @@ function AttendancePage() {
             <div>
               <label htmlFor="attendanceDate" className="block text-sm font-medium text-gray-700 mb-1">วันที่</label>
               <input
-                type="date"
+                type="text"
                 id="attendanceDate"
-                lang="en-GB"
-                value={attendanceDate}
-                onChange={(e) => setAttendanceDate(e.target.value)}
+                value={attendanceDateDisplay}
+                onChange={(e) => {
+                  setAttendanceDateDisplay(e.target.value);
+                  setAttendanceDate(ddmmyyyyToIso(e.target.value));
+                }}
+                placeholder="dd/mm/yyyy"
+                pattern="\d{2}/\d{2}/\d{4}"
                 className="text-gray-900 mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
                 required
               />

--- a/client/src/utils/date.js
+++ b/client/src/utils/date.js
@@ -26,3 +26,16 @@ export function getNextMonth(monthStr) {
   date.setMonth(date.getMonth() + 1);
   return date.toISOString().slice(0, 7);
 }
+
+export function isoToDDMMYYYY(isoStr) {
+  if (!isoStr) return '';
+  const [year, month, day] = isoStr.split('-');
+  return `${day}/${month}/${year}`;
+}
+
+export function ddmmyyyyToIso(ddmmyyyy) {
+  if (!ddmmyyyy) return '';
+  const [day, month, year] = ddmmyyyy.split('/');
+  if (!day || !month || !year) return '';
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary
- adjust HTML lang attribute to `en-GB`
- hard code attendance page date input to dd/mm/yyyy

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853b1141bb08323a5eaaac80d082f20