### PR TITLE
Hide cleared advances and split advance history

### DIFF
--- a/client/src/pages/AdvanceHistoryPage.jsx
+++ b/client/src/pages/AdvanceHistoryPage.jsx
@@ -47,6 +47,8 @@ function AdvanceHistoryPage() {
   }, {});
 
   const list = Object.values(grouped);
+  const inProcess = list.filter(a => a.total_amount !== 0);
+  const finished = list.filter(a => a.total_amount === 0);
 
   return (
     <div className="p-6 text-black">
@@ -57,7 +59,47 @@ function AdvanceHistoryPage() {
           <option key={e.id} value={e.id}>{`${e.first_name} ${e.last_name}`}</option>
         ))}
       </select>
-      {list.map(adv => (
+      {inProcess.length > 0 && (
+        <h3 className="text-lg font-semibold mb-2">in process</h3>
+      )}
+      {inProcess.map(adv => (
+        <div key={adv.id} className="mb-6 bg-white shadow p-4 rounded">
+          <div className="font-semibold mb-2">{adv.name} - ยอดคงเหลือ {adv.total_amount}</div>
+          {adv.transactions.length > 0 ? (
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-100">
+                <tr>
+                  <th className="px-2 py-1 text-left">วันที่</th>
+                  <th className="px-2 py-1 text-left">ประเภท</th>
+                  <th className="px-2 py-1 text-left">จำนวน</th>
+                  <th className="px-2 py-1 text-left">หมายเหตุ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {adv.transactions.map(t => {
+                  const amt = Number(t.amount);
+                  const isAdd = amt >= 0;
+                  return (
+                    <tr key={t.id} className="border-t">
+                      <td className="px-2 py-1">{t.date}</td>
+                      <td className="px-2 py-1">{isAdd ? 'เบิกเพิ่ม' : 'หักเงินเบิก'}</td>
+                      <td className={`px-2 py-1 ${isAdd ? 'text-red-600' : 'text-green-600'}`}>{t.amount}</td>
+                      <td className="px-2 py-1">{t.remark}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : (
+            <div className="text-sm text-gray-500">ไม่มีประวัติ</div>
+          )}
+        </div>
+      ))}
+
+      {finished.length > 0 && (
+        <h3 className="text-lg font-semibold mt-4 mb-2">finished</h3>
+      )}
+      {finished.map(adv => (
         <div key={adv.id} className="mb-6 bg-white shadow p-4 rounded">
           <div className="font-semibold mb-2">{adv.name} - ยอดคงเหลือ {adv.total_amount}</div>
           {adv.transactions.length > 0 ? (

--- a/client/src/pages/DeductionManagementPage.jsx
+++ b/client/src/pages/DeductionManagementPage.jsx
@@ -58,7 +58,13 @@ function DeductionManagementPage() {
   const fetchAdvances = async () => {
     try {
       const res = await axios.get('/api/advances');
-      setAdvances(res.data.map(a => ({ ...a, addAmount: '', addDate: new Date().toISOString().slice(0,10), remark: '' })));
+      const active = res.data.filter(a => a.total_amount !== 0);
+      setAdvances(active.map(a => ({
+        ...a,
+        addAmount: '',
+        addDate: new Date().toISOString().slice(0, 10),
+        remark: ''
+      })));
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Summary
- hide advances that are already cleared in Deduction Management page
- split Advance History page into "in process" and "finished" sections

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853c15f3db4832391ceb47a98bc37d5