### PR TITLE
Cap deduction totals during history edit

### DIFF
--- a/client/src/pages/PayrollHistoryPage.jsx
+++ b/client/src/pages/PayrollHistoryPage.jsx
@@ -160,6 +160,7 @@ function PayrollHistoryPage() {
       amt = Math.min(amt, DEDUCTION_CAP);
       dedType += amt;
     });
+    dedType = Math.min(dedType, DEDUCTION_CAP);
     const otherDed = dedType + advTotal + savingsDep;
     const deductionsTotal =
       (parseFloat(rec.water_deduction) || 0) +

--- a/server/src/controllers/payrollController.js
+++ b/server/src/controllers/payrollController.js
@@ -852,6 +852,7 @@ exports.updateMonthlyRecord = async (req, res) => {
       amount = Math.min(amount, DEDUCTION_CAP);
       otherDed += amount;
     }
+    otherDed = Math.min(otherDed, DEDUCTION_CAP);
 
     const { rows: adv } = await pool.query(
       `SELECT -t.amount AS amount
@@ -1032,6 +1033,7 @@ exports.updateSemiMonthlyRecord = async (req, res) => {
       amount = Math.min(amount, DEDUCTION_CAP);
       otherDed += amount;
     }
+    otherDed = Math.min(otherDed, DEDUCTION_CAP);
 
     const { rows: adv } = await pool.query(
       `SELECT -t.amount AS amount
@@ -1097,6 +1099,7 @@ exports.updateSemiMonthlyRecord = async (req, res) => {
         amount = Math.min(amount, DEDUCTION_CAP);
         otherDed2 += amount;
       }
+      otherDed2 = Math.min(otherDed2, DEDUCTION_CAP);
 
       const { rows: adv2 } = await pool.query(
         `SELECT -t.amount AS amount


### PR DESCRIPTION
## Summary
- enforce a 750 cap on the sum of deduction type amounts when editing payroll history
- apply the same cap server-side for monthly and semi-monthly record updates

## Testing
- `npm run lint` in `client`
- `npm run lint` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68543da60fe883238ed1b46b10fadf6d